### PR TITLE
Add devices null check code

### DIFF
--- a/src/darwin_list.cpp
+++ b/src/darwin_list.cpp
@@ -281,7 +281,7 @@ void EIO_List(uv_work_t* req) {
   }
 
   stDeviceListItem* devices = GetSerialDevices();
-  if (*(devices->length) > 0) {
+  if (devices != NULL && *(devices->length) > 0) {
     stDeviceListItem* next = devices;
 
     for (int i = 0, len = *(devices->length); i < len; i++) {


### PR DESCRIPTION
If no device is connected in the Mac operating system, `Segmentation fault: 11` error will occur.

because the length of the NULL value is checked.

So a NULL check code was inserted.