### PR TITLE
Adding in port selection to serialport-term.

### DIFF
--- a/bin/terminal.js
+++ b/bin/terminal.js
@@ -46,7 +46,7 @@ function setupPort() {
       console.error('Error listing ports, and missing port argument.', err);
       args.outputHelp();
       args.missingArgument('port');
-      process.exit(-1);
+      process.exit(4);
     } else {
       if (ports.length > 0) {
         const portSelection = new List({
@@ -63,12 +63,12 @@ function setupPort() {
           })
           .catch(error => {
             console.log(`Could not select a port: ${error}`);
-            process.exit(-2);
+            process.exit(2);
           });
       } else {
         args.outputHelp();
         args.missingArgument('port');
-        process.exit(-1);
+        process.exit(3);
       }
     }
   });

--- a/bin/terminal.js
+++ b/bin/terminal.js
@@ -37,7 +37,7 @@ function listPorts() {
 };
 
 function setupPort() {
-  if(args.port) {
+  if (args.port) {
     createPort(args.port);
   }
 
@@ -48,13 +48,13 @@ function setupPort() {
       args.missingArgument('port');
       process.exit(-1);
     } else {
-      if(ports.length > 0) {
-        var portSelection = new List({
+      if (ports.length > 0) {
+        const portSelection = new List({
           name: 'serial-port-selection',
           message: 'Select a serial port to open',
           choices: ports.map((port, i) => `[${i + 1}]\t${port.comName}\t${port.pnpId || ''}\t${port.manufacturer || ''}`)
         });
-  
+
         portSelection.run()
           .then(answer => {
             const choice = answer.split('\t')[1];

--- a/bin/terminal.js
+++ b/bin/terminal.js
@@ -12,10 +12,9 @@ function makeNumber(input) {
 
 args
   .version(version)
-  .usage('-p <port> [options]')
+  .usage('[options]')
   .description('A basic terminal interface for communicating over a serial port. Pressing ctrl+c exits.')
   .option('-l --list', 'List available ports then exit')
-  // TODO make the port not a flag as it's always required
   .option('-p, --port <port>', 'Path or Name of serial port')
   .option('-b, --baud <baudrate>', 'Baud rate default: 9600', makeNumber, 9600)
   .option('--databits <databits>', 'Data bits default: 8', makeNumber, 8)

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "nan": "^2.6.2",
     "prebuild-install": "^2.4.1",
     "promirepl": "^1.0.1",
+    "prompt-list": "^3.1.2",
     "safe-buffer": "^5.0.1"
   },
   "devDependencies": {
@@ -99,6 +100,7 @@
     "lint": "eslint lib test bin examples",
     "rebuild-all": "npm rebuild && node-gyp rebuild",
     "repl": "node bin/repl.js",
+    "terminal": "node bin/terminal.js",
     "stress": "mocha --no-timeouts test/arduinoTest/stress.js",
     "test": "istanbul cover ./node_modules/mocha/bin/_mocha",
     "test:watch": "mocha -w",


### PR DESCRIPTION
This makes the terminal command much more usable when you need to open
it multiple times in a row; especially when the names of the serial ports
are rapidly changing.

<img width="785" alt="screen shot 2018-01-21 at 1 30 35 pm" src="https://user-images.githubusercontent.com/149178/35190234-caaff5ec-feb0-11e7-9925-c1e1ef0f8c0a.png">

At the moment, I'm doing a bunch of development on the nRF5 series of SOC's from Nordic Semiconductor and, because this is Bluetooth, I often have more than one SOC connected to my computer. Also, every time that I plug a new device in the [Silicon Labs driver](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers) gives me a new virtual port for the device; making it a more lengthy than required process to reconnect to my logs. It would be better if it would just be:

 1. Ctrl-C 
 1. Rerun terminal
 1. Select the newly named port.
 1. Profit

At any rate, hopefully, you like these changes.