### PR TITLE
Adding option to include delimiter in the DelimiterParser transform.

### DIFF
--- a/lib/parsers/delimiter.js
+++ b/lib/parsers/delimiter.js
@@ -27,6 +27,7 @@ class DelimiterParser extends Transform {
       throw new TypeError('"delimiter" has a 0 or undefined length');
     }
 
+    this.includeDelimiter = options.includeDelimiter !== undefined ? options.includeDelimiter : false;
     this.delimiter = Buffer.from(options.delimiter);
     this.buffer = Buffer.alloc(0);
   }
@@ -35,7 +36,7 @@ class DelimiterParser extends Transform {
     let data = Buffer.concat([this.buffer, chunk]);
     let position;
     while ((position = data.indexOf(this.delimiter)) !== -1) {
-      this.push(data.slice(0, position));
+      this.push(data.slice(0, position + (this.includeDelimiter ? this.delimiter.length : 0)));
       data = data.slice(position + this.delimiter.length);
     }
     this.buffer = data;

--- a/test/parser-delimiter.js
+++ b/test/parser-delimiter.js
@@ -15,11 +15,30 @@ describe('DelimiterParser', () => {
     parser.on('data', spy);
     parser.write(Buffer.from('I love robots\nEach '));
     parser.write(Buffer.from('and Every One\n'));
+    parser.write(Buffer.from('\n'));
     parser.write(Buffer.from('even you!'));
 
     assert.deepEqual(spy.getCall(0).args[0], Buffer.from('I love robots'));
     assert.deepEqual(spy.getCall(1).args[0], Buffer.from('Each and Every One'));
     assert(spy.calledTwice);
+  });
+
+  it('includes delimiter when includeDelimiter is true', () => {
+    const spy = sinon.spy();
+    const parser = new DelimiterParser({
+      delimiter: Buffer.from('\n'),
+      includeDelimiter: true
+    });
+    parser.on('data', spy);
+    parser.write(Buffer.from('I love robots\nEach '));
+    parser.write(Buffer.from('and Every One\n'));
+    parser.write(Buffer.from('\n'));
+    parser.write(Buffer.from('even you!'));
+
+    assert.deepEqual(spy.getCall(0).args[0], Buffer.from('I love robots\n'));
+    assert.deepEqual(spy.getCall(1).args[0], Buffer.from('Each and Every One\n'));
+    assert.deepEqual(spy.getCall(2).args[0], Buffer.from('\n'));
+    assert.equal(spy.callCount, 3);
   });
 
   it('flushes remaining data when the stream ends', () => {


### PR DESCRIPTION
This PR adds a `includeDelimiter` boolean option to the `DelimiterParser` that includes the delimiter in its output.

In the `4.x` series, I used the `DelimiterParser` relying on this, because some of the protocols used in the devices I'm operating with responds with a single delimiter as an `ACK`. The new transform does not trigger an event when an empty delimiter is sent. I added a new line to the first test to illustrate this, sending a single delimiter to the parser and assuring the Sinon spy is only called twice.

I also added a new test with `includeDelimiter: true`.

Thanks for you work!