### PR TITLE
Building against NW.js headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,24 @@ To recompile `serialport` (or any native Node.js module) for Electron, you can u
 
 For an example project, check out [`electron-serialport`](https://github.com/johnny-five-io/electron-serialport).
 
+#### NW.js
+
+[NW.js](https://nwjs.io/) is an app runtime based on Chromium and node.js.
+
+Like Electron, NW.js also requires compilation against its own specific headers.
+
+To instruct `prebuild` to build against the correct headers, place a file named `.prebuildrc` on your package root with the following content:
+
+```
+build_from_source=true
+runtime=node-webkit
+target=<target_version>
+```
+
+Where `<target_version>` is the NW.js version you are building against (for example, `0.26.6`).
+
+OBS: NW.js support requires `prebuild >= 7.3.0`.
+
 #### Illegal Instruction
 
 The pre-compiled binaries assume a fully capable chip. Intel's [Galileo 2](https://software.intel.com/en-us/iot/hardware/galileo), for example, lacks a few instruction sets from the `ia32` architecture. A few other platforms have similar issues. If you get `Illegal Instruction` when trying to run Node-Serialport, you'll need to ask npm to rebuild the Serialport binary.

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "istanbul": "^0.4.4",
     "jsdoc": "^3.5.5",
     "mocha": "^4.0.0",
-    "prebuild": "^7.0.0",
+    "prebuild": "^7.4.0",
     "proxyquire": "^1.7.10",
     "sinon": "^4.1.5"
   },


### PR DESCRIPTION
NW.js support was recently added to `prebuild`:

https://github.com/lgeiger/node-abi/pull/34
https://github.com/prebuild/prebuild/pull/203

This PR bumps the minimal `prebuild` version to `7.4.0` to ensure NW.js support, and updates the README with NW.js build info.