### PR TITLE
Fix examples on case sensitive filesystems

### DIFF
--- a/lib/parsers/byte-length.js
+++ b/lib/parsers/byte-length.js
@@ -11,7 +11,7 @@ const Transform = require('stream').Transform;
 To use the `ByteLength` parser:
 ```js
 const SerialPort = require('serialport');
-const ByteLength = SerialPort.parsers.ByteLength
+const ByteLength = SerialPort.parsers.byteLength
 const port = new SerialPort('/dev/tty-usbserial1');
 const parser = port.pipe(new ByteLength({length: 8}));
 parser.on('data', console.log); // will have 8 bytes per data event

--- a/lib/parsers/cctalk.js
+++ b/lib/parsers/cctalk.js
@@ -8,7 +8,7 @@ const Buffer = require('safe-buffer').Buffer;
 CCTalk Messages are emitted as buffers.
 ```js
 const SerialPort = require('serialport');
-const CCTalk = SerialPort.parsers.CCTalk;
+const CCTalk = SerialPort.parsers.cctalk;
 const port = new SerialPort('/dev/ttyUSB0');
 const parser = port.pipe(new CCtalk());
 parser.on('data', console.log);

--- a/lib/parsers/delimiter.js
+++ b/lib/parsers/delimiter.js
@@ -8,7 +8,7 @@ const Transform = require('stream').Transform;
 To use the `Delimiter` parser, provide a delimiter as a string, buffer, or array of bytes:
 ```js
 const SerialPort = require('serialport');
-const Delimiter = SerialPort.parsers.Delimiter;
+const Delimiter = SerialPort.parsers.delimiter;
 const port = new SerialPort('/dev/tty-usbserial1');
 const parser = port.pipe(new Delimiter({ delimiter: Buffer.from('EOL') }));
 parser.on('data', console.log);

--- a/lib/parsers/index.js
+++ b/lib/parsers/index.js
@@ -15,7 +15,7 @@
  * @example
 ```js
 const SerialPort = require('serialport');
-const Readline = SerialPort.parsers.Readline;
+const Readline = SerialPort.parsers.readline;
 const port = new SerialPort('/dev/tty-usbserial1');
 const parser = new Readline();
 port.pipe(parser);

--- a/lib/parsers/readline.js
+++ b/lib/parsers/readline.js
@@ -8,7 +8,7 @@ const DelimiterParser = require('./delimiter');
 To use the `Readline` parser, provide a delimiter (defaults to '\n'). Data is emitted as string controllable by the `encoding` option (defaults to `utf8`).
 ```js
 const SerialPort = require('serialport');
-const Readline = SerialPort.parsers.Readline;
+const Readline = SerialPort.parsers.readline;
 const port = new SerialPort('/dev/tty-usbserial1');
 const parser = port.pipe(new Readline({ delimiter: '\r\n' }));
 parser.on('data', console.log);

--- a/lib/parsers/ready.js
+++ b/lib/parsers/ready.js
@@ -8,7 +8,7 @@ const Transform = require('stream').Transform;
 To use the `Ready` parser provide a byte start sequence. After the bytes have been received a ready event is fired and data events are passed through.
 ```js
 const SerialPort = require('serialport');
-const Ready = SerialPort.parsers.Ready;
+const Ready = SerialPort.parsers.ready;
 const port = new SerialPort('/dev/tty-usbserial1');
 const parser = port.pipe(new Ready({ delimiter: 'READY' }));
 parser.on('ready', () => console.log('the ready byte sequence has been received'))

--- a/lib/parsers/regex.js
+++ b/lib/parsers/regex.js
@@ -7,7 +7,7 @@ const Transform = require('stream').Transform;
 To use the `Regex` parser provide a regular expression to split the incoming text upon. Data is emitted as string controllable by the `encoding` option (defaults to `utf8`).
 ```js
 const SerialPort = require('serialport');
-const Regex = SerialPort.parsers.Regex;
+const Regex = SerialPort.parsers.regex;
 const port = new SerialPort('/dev/tty-usbserial1');
 const parser = port.pipe(new Regex({ regex: /[\r\n]+/ }));
 parser.on('data', console.log);


### PR DESCRIPTION
On case sensitive filesystems (Windows), this did not work:
```
const Readline = SerialPort.parsers.Readline;
```
This did:
```
const Readline = SerialPort.parsers.readline;
```

I'm not too familiar with Node, so I'm not sure what's the role of `index.js` here, but at least here's a suggested fix.