### PR TITLE
Fix test timeouts and change test jig

### DIFF
--- a/test/bindings.js
+++ b/test/bindings.js
@@ -427,7 +427,8 @@ function testBinding(bindingName, Binding, testPort) {
         }
 
         let binding;
-        beforeEach(() => {
+        beforeEach(function () {
+          this.timeout(20000);
           binding = new Binding({
             disconnect
           });

--- a/test/bindings.js
+++ b/test/bindings.js
@@ -557,7 +557,8 @@ function testBinding(bindingName, Binding, testPort) {
         beforeEach(() => {
           buffer = Buffer.alloc(readyData.length);
           binding = new Binding({ disconnect });
-          return binding.open(testPort, defaultOpenOptions);
+          return binding.open(testPort, defaultOpenOptions)
+            .then(() => binding.write(buffer));
         });
 
         afterEach(() => binding.close());

--- a/test/bindings.js
+++ b/test/bindings.js
@@ -390,7 +390,10 @@ function testBinding(bindingName, Binding, testPort) {
           return binding.open(testPort, defaultOpenOptions);
         });
 
-        afterEach(() => binding.close());
+        afterEach(function () {
+          this.timeout(20000);
+          binding.close();
+        });
 
         it('resolves after a small write', () => {
           const data = Buffer.from('simple write of 24 bytes');

--- a/test/integration.js
+++ b/test/integration.js
@@ -35,7 +35,7 @@ function integrationTest(platform, testPort, Binding) {
 
   describe(`${platform} SerialPort Integration Tests`, () => {
     if (!testPort) {
-      it(`${platform} tests requires an Arduino loaded with the arduinoEcho program on a serialport set to the TEST_PORT env var`);
+      it(`${platform} tests requires a serial device, such as an Arduino or FTDI module, with shorted TX and RX pins with the TEST_PORT env var set to its address (/dev/ttyXXXX, COMX or similar for your platform)`);
       return;
     }
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -175,7 +175,8 @@ function integrationTest(platform, testPort, Binding) {
     });
 
     describe('#update', () => {
-      testFeature('port.update-baudrate', 'allows changing the baud rate of an open port', (done) => {
+      testFeature('port.update-baudrate', 'allows changing the baud rate of an open port', function (done) {
+        this.timeout(6000);
         const port = new SerialPort(testPort, () => {
           port.update({ baudRate: 57600 }, (err) => {
             assert.isNull(err);

--- a/test/integration.js
+++ b/test/integration.js
@@ -245,6 +245,7 @@ function integrationTest(platform, testPort, Binding) {
         const port = new SerialPort(testPort);
         port.on('error', done);
         const ready = port.pipe(new SerialPort.parsers.Ready({ delimiter: 'READY' }));
+        port.write(readyData);
         ready.on('ready', () => {
           // we should have a pending read now since we're in flowing mode
           port.flush((err) => {

--- a/test/integration.js
+++ b/test/integration.js
@@ -143,7 +143,7 @@ function integrationTest(platform, testPort, Binding) {
 
         port.open((err) => {
           assert.isNull(err);
-          port.write("READY");
+          port.write(readyData);
         });
         port.once('data', () => {
           port.close();
@@ -153,7 +153,7 @@ function integrationTest(platform, testPort, Binding) {
           assert.isNull(err);
           port.open((err) => {
             assert.isNull(err);
-            port.write("READY");
+            port.write(readyData);
           });
           port.once('data', () => {
             port.close(done);

--- a/test/integration.js
+++ b/test/integration.js
@@ -143,6 +143,7 @@ function integrationTest(platform, testPort, Binding) {
 
         port.open((err) => {
           assert.isNull(err);
+          port.write("READY");
         });
         port.once('data', () => {
           port.close();
@@ -152,6 +153,7 @@ function integrationTest(platform, testPort, Binding) {
           assert.isNull(err);
           port.open((err) => {
             assert.isNull(err);
+            port.write("READY");
           });
           port.once('data', () => {
             port.close(done);

--- a/test/integration.js
+++ b/test/integration.js
@@ -195,9 +195,10 @@ function integrationTest(platform, testPort, Binding) {
         port.on('error', done);
         const ready = port.pipe(new SerialPort.parsers.Ready({ delimiter: readyData }));
 
+        port.write(readyData);
         // this will trigger from the "READY" the arduino sends when it's... ready
         ready.on('ready', () => {
-          port.write(input);
+          port.flush(() => port.write(input));
         });
 
         const readData = Buffer.alloc(input.length, 0);


### PR DESCRIPTION
This patch solves a number of timeout bugs in the binding and serial integration tests on linux (did not check on other platforms) which were preventing full passes.

It also changes the advised test setup from an Arduino with the arduinoEcho.ino sketch to any serial device with the rx and tx pins bridged excluding devices that use the ACM driver on linux.

The old test rig also still works aside from the ACM driver versions of arduino due to the ACM driver hanging on close instead of erroring (expected behavior but there will be another patch addressing this). This particular failing test means that the integration test likely never worked for Arduino UNOs and above that all use ttyACMx for interfacing.

Review and comments welcome.