### PR TITLE
Alpine Linux: Adds missing header file for musl libc

### DIFF
--- a/src/serialport_linux.cpp
+++ b/src/serialport_linux.cpp
@@ -1,6 +1,7 @@
 #if defined(__linux__)
 
 #include <sys/ioctl.h>
+#include <asm/ioctls.h>
 #include <asm/termbits.h>
 
 // Uses the termios2 interface to set nonstandard baud rates


### PR DESCRIPTION
Fixes #1470  After adding the new custom baud rate implementation for Linux, a build breaking bug occurred on Alpine Linux due to musl's handling of the kernel header files involved with ioctls. This patch introduces a fix by using the solution found [here](https://github.com/tio/tio/pull/65) on a similar, serial oriented project.

Tested in an Alpine Linux docker container. Passing all hardware tests.