### PR TITLE
Added 'cc' to lint the C++ code on 'npm lint'

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "devDependencies": {
     "bluebird": "^3.5.0",
+    "cc": "^1.0.1",
     "chai": "^4.0.2",
     "chai-subset": "^1.5.0",
     "conventional-changelog-cli": "^1.3.2",
@@ -97,7 +98,7 @@
     "arduino-test": "TEST_PORT=$(./bin/find-arduino.js) npm test",
     "changelog": "conventional-changelog -i CHANGELOG.md -s",
     "docs": "jsdoc -c ./.jsdoc.json ",
-    "lint": "eslint lib test bin examples",
+    "lint": "eslint lib test bin examples && cc",
     "rebuild-all": "npm rebuild && node-gyp rebuild",
     "repl": "node bin/repl.js",
     "terminal": "node bin/terminal.js",
@@ -111,5 +112,16 @@
     "prebuild": "prebuild --all --strip --verbose",
     "prebuild-upload": "prebuild --all --strip --verbose"
   },
-  "gypfile": true
+  "gypfile": true,
+  "cc": {
+    "filter": [
+      "legal/copyright",
+      "build/include"
+    ],
+    "files": [
+        "src/*.cpp",
+        "src/*.h"
+    ],
+    "linelength": "120"
+  }
 }

--- a/src/darwin_list.h
+++ b/src/darwin_list.h
@@ -1,8 +1,9 @@
-#ifndef SRC_SERIALPORT_DARWIN_LIST_H_
-#define SRC_SERIALPORT_DARWIN_LIST_H_
+#ifndef SRC_DARWIN_LIST_H_
+#define SRC_DARWIN_LIST_H_
+#include <sys/param.h>  // For MAXPATHLEN
 #include <nan.h>
 #include <list>
-#include <sys/param.h> // For MAXPATHLEN
+#include <string>
 
 #define ERROR_STRING_SIZE 1024
 
@@ -41,4 +42,4 @@ typedef struct DeviceListItem {
     int* length;
 } stDeviceListItem;
 
-#endif  // SRC_SERIALPORT_DARWIN_LIST_H_
+#endif  // SRC_DARWIN_LIST_H_

--- a/src/poller.cpp
+++ b/src/poller.cpp
@@ -19,7 +19,7 @@ Poller::~Poller() {
   // if we call uv_poll_stop after uv_poll_init failed we segfault
   if (uv_poll_init_success) {
     uv_poll_stop(poll_handle);
-    uv_close((uv_handle_t*) poll_handle, Poller::onClose);
+    uv_close(reinterpret_cast<uv_handle_t*> (poll_handle), Poller::onClose);
   } else {
     delete poll_handle;
   }

--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -54,7 +54,7 @@ NAN_METHOD(Open) {
   }
 
   OpenBaton* baton = new OpenBaton();
-  strcpy(baton->path, *path);
+  snprintf(baton->path, sizeof(baton->path), *path);
   baton->baudRate = getIntFromObject(options, "baudRate");
   baton->dataBits = getIntFromObject(options, "dataBits");
   baton->parity = ToParityEnum(getStringFromObj(options, "parity"));

--- a/src/serialport_linux.cpp
+++ b/src/serialport_linux.cpp
@@ -8,7 +8,7 @@
 int linuxSetCustomBaudRate(const int fd, const unsigned int baudrate) {
     struct termios2 t;
 
-    if(ioctl(fd, TCGETS2, &t)) {
+    if (ioctl(fd, TCGETS2, &t)) {
       return -1;
     }
 
@@ -16,7 +16,7 @@ int linuxSetCustomBaudRate(const int fd, const unsigned int baudrate) {
     t.c_cflag |= BOTHER;
     t.c_ospeed = t.c_ispeed = baudrate;
 
-    if(ioctl(fd, TCSETS2, &t)) {
+    if (ioctl(fd, TCSETS2, &t)) {
       return -2;
     }
 
@@ -27,11 +27,11 @@ int linuxSetCustomBaudRate(const int fd, const unsigned int baudrate) {
 int linuxGetSystemBaudRate(const int fd, int* const outbaud) {
   struct termios2 t;
 
-  if(ioctl(fd, TCGETS2, &t)) {
+  if (ioctl(fd, TCGETS2, &t)) {
     return -1;
   }
 
-  *outbaud = (int)t.c_ospeed;
+  *outbaud = static_cast<int>(t.c_ospeed);
 
   return 0;
 }

--- a/src/serialport_linux.h
+++ b/src/serialport_linux.h
@@ -1,8 +1,8 @@
-#ifndef CUSTOM_BAUDRATE_H
-#define CUSTOM_BAUDRATE_H
+#ifndef SRC_SERIALPORT_LINUX_H_
+#define SRC_SERIALPORT_LINUX_H_
 
 int linuxSetCustomBaudRate(const int fd, const unsigned int baudrate);
 int linuxGetSystemBaudRate(const int fd, int* const outbaud);
 
-#endif
+#endif  // SRC_SERIALPORT_LINUX_H_
 

--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -1,5 +1,5 @@
-#include "./serialport_unix.h"
-#include "./serialport.h"
+#include "serialport_unix.h"
+#include "serialport.h"
 
 #include <sys/file.h>
 #include <unistd.h>
@@ -15,13 +15,11 @@
 #if defined(MAC_OS_X_VERSION_10_4) && (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_4)
 #include <sys/ioctl.h>
 #include <IOKit/serial/ioss.h>
-#endif
 
-#if defined(__OpenBSD__)
+#elif defined(__OpenBSD__)
 #include <sys/ioctl.h>
-#endif
 
-#if defined(__linux__)
+#elif defined(__linux__)
 #include <sys/ioctl.h>
 #include <linux/serial.h>
 #include "serialport_linux.h"
@@ -105,7 +103,8 @@ int setBaudRate(ConnectionOptionsBaton *data) {
   // get port options
   struct termios options;
   if (-1 == tcgetattr(fd, &options)) {
-    snprintf(data->errorString, sizeof(data->errorString), "Error: %s setting custom baud rate of %d", strerror(errno), data->baudRate);
+    snprintf(data->errorString, sizeof(data->errorString),
+             "Error: %s setting custom baud rate of %d", strerror(errno), data->baudRate);
     return -1;
   }
 
@@ -115,10 +114,12 @@ int setBaudRate(ConnectionOptionsBaton *data) {
       int err = linuxSetCustomBaudRate(fd, data->baudRate);
 
       if (err == -1) {
-        snprintf(data->errorString, sizeof(data->errorString), "Error: %s || while retrieving termios2 info", strerror(errno));
+        snprintf(data->errorString, sizeof(data->errorString),
+                 "Error: %s || while retrieving termios2 info", strerror(errno));
         return -1;
-      } else if(err == -2) {
-        snprintf(data->errorString, sizeof(data->errorString), "Error: %s || while setting custom baud rate of %d", strerror(errno), data->baudRate);
+      } else if (err == -2) {
+        snprintf(data->errorString, sizeof(data->errorString),
+                 "Error: %s || while setting custom baud rate of %d", strerror(errno), data->baudRate);
         return -1;
       }
 
@@ -131,7 +132,8 @@ int setBaudRate(ConnectionOptionsBaton *data) {
     if (-1 == baudRate) {
       speed_t speed = data->baudRate;
       if (-1 == ioctl(fd, IOSSIOSPEED, &speed)) {
-        snprintf(data->errorString, sizeof(data->errorString), "Error: %s calling ioctl(.., IOSSIOSPEED, %ld )", strerror(errno), speed );
+        snprintf(data->errorString, sizeof(data->errorString),
+                 "Error: %s calling ioctl(.., IOSSIOSPEED, %ld )", strerror(errno), speed);
         return -1;
       } else {
         tcflush(fd, TCIOFLUSH);
@@ -141,7 +143,8 @@ int setBaudRate(ConnectionOptionsBaton *data) {
   #endif
 
   if (-1 == baudRate) {
-    snprintf(data->errorString, sizeof(data->errorString), "Error baud rate of %d is not supported on your platform", data->baudRate);
+    snprintf(data->errorString, sizeof(data->errorString),
+             "Error baud rate of %d is not supported on your platform", data->baudRate);
     return -1;
   }
 
@@ -163,7 +166,8 @@ void EIO_Update(uv_work_t* req) {
 int setup(int fd, OpenBaton *data) {
   int dataBits = ToDataBitsConstant(data->dataBits);
   if (-1 == dataBits) {
-    snprintf(data->errorString, sizeof(data->errorString), "Invalid data bits setting %d", data->dataBits);
+    snprintf(data->errorString, sizeof(data->errorString),
+             "Invalid data bits setting %d", data->dataBits);
     return -1;
   }
 
@@ -299,7 +303,8 @@ void EIO_Close(uv_work_t* req) {
   VoidBaton* data = static_cast<VoidBaton*>(req->data);
 
   if (-1 == close(data->fd)) {
-    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, unable to close fd %d", strerror(errno), data->fd);
+    snprintf(data->errorString, sizeof(data->errorString),
+             "Error: %s, unable to close fd %d", strerror(errno), data->fd);
   }
 }
 
@@ -370,7 +375,7 @@ void EIO_GetBaudRate(uv_work_t* req) {
   }
   #endif
 
-  // TODO implement on mac
+  // TODO(Fumon) implement on mac
   #if defined(MAC_OS_X_VERSION_10_4) && (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_4)
   snprintf(data->errorString, sizeof(data->errorString), "Error: System baud rate check not implemented on darwin");
   return;

--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -7,7 +7,7 @@
 #include <windows.h>
 #include <Setupapi.h>
 #include <devguid.h>
-#pragma comment (lib, "setupapi.lib")
+#pragma comment(lib, "setupapi.lib")
 
 #define MAX_BUFFER_SIZE 1000
 
@@ -32,16 +32,15 @@ void ErrorCodeToString(const char* prefix, int errorCode, char *errorStr) {
     break;
   case ERROR_INVALID_PARAMETER:
     _snprintf_s(errorStr, ERROR_STRING_SIZE, _TRUNCATE, "%s: The parameter is incorrect", prefix);
-    break;      
+    break;
   default:
     _snprintf_s(errorStr, ERROR_STRING_SIZE, _TRUNCATE, "%s: Unknown error code %d", prefix, errorCode);
     break;
   }
 }
 
-void AsyncCloseCallback(uv_handle_t* handle)
-{
-  uv_async_t* async = (uv_async_t*)handle;
+void AsyncCloseCallback(uv_handle_t* handle) {
+  uv_async_t* async = reinterpret_cast<uv_async_t*>(handle);
   delete async;
 }
 
@@ -68,8 +67,7 @@ void EIO_Open(uv_work_t* req) {
     NULL,
     OPEN_EXISTING,
     FILE_FLAG_OVERLAPPED,  // allows for reading and writing at the same time and sets the handle for asynchronous I/O
-    NULL
-  );
+    NULL);
 
   if (file == INVALID_HANDLE_VALUE) {
     DWORD errorCode = GetLastError();
@@ -164,11 +162,11 @@ void EIO_Open(uv_work_t* req) {
   // Set the timeouts for read and write operations.
   // Read operation will wait for at least 1 byte to be received.
   COMMTIMEOUTS commTimeouts = {};
-  commTimeouts.ReadIntervalTimeout = 0;         // Never timeout, always wait for data.
-  commTimeouts.ReadTotalTimeoutMultiplier = 0;  // Do not allow big read timeout when big read buffer used
-  commTimeouts.ReadTotalTimeoutConstant = 0;    // Total read timeout (period of read loop)
-  commTimeouts.WriteTotalTimeoutConstant = 0;   // Const part of write timeout
-  commTimeouts.WriteTotalTimeoutMultiplier = 0; // Variable part of write timeout (per byte)
+  commTimeouts.ReadIntervalTimeout = 0;          // Never timeout, always wait for data.
+  commTimeouts.ReadTotalTimeoutMultiplier = 0;   // Do not allow big read timeout when big read buffer used
+  commTimeouts.ReadTotalTimeoutConstant = 0;     // Total read timeout (period of read loop)
+  commTimeouts.WriteTotalTimeoutConstant = 0;    // Const part of write timeout
+  commTimeouts.WriteTotalTimeoutMultiplier = 0;  // Variable part of write timeout (per byte)
 
   if (!SetCommTimeouts(file, &commTimeouts)) {
     ErrorCodeToString("Open (SetCommTimeouts)", GetLastError(), data->errorString);
@@ -180,7 +178,7 @@ void EIO_Open(uv_work_t* req) {
   PurgeComm(file, PURGE_RXCLEAR);
   PurgeComm(file, PURGE_TXCLEAR);
 
-  data->result = (int)file;
+  data->result = (int)file;  // NOLINT
 }
 
 void EIO_Update(uv_work_t* req) {
@@ -270,7 +268,7 @@ void EIO_GetBaudRate(uv_work_t* req) {
     return;
   }
 
-  data->baudRate = (int)dcb.BaudRate;
+  data->baudRate = static_cast<int>(dcb.BaudRate);
 }
 
 bool IsClosingHandle(int fd) {
@@ -352,7 +350,8 @@ DWORD __stdcall WriteThread(LPVOID param) {
     char* offsetPtr = baton->bufferData + baton->offset;
     // WriteFileEx requires calling GetLastError even upon success. Clear the error beforehand.
     SetLastError(0);
-    WriteFileEx((HANDLE)baton->fd, offsetPtr, static_cast<DWORD>(baton->bufferLength - baton->offset), ov, WriteIOCompletion);
+    WriteFileEx((HANDLE)baton->fd, offsetPtr,
+                static_cast<DWORD>(baton->bufferLength - baton->offset), ov, WriteIOCompletion);
     // Error codes when call is successful, such as ERROR_MORE_DATA.
     DWORD lastError = GetLastError();
     if (lastError != ERROR_SUCCESS) {
@@ -373,7 +372,7 @@ void EIO_AfterWrite(uv_async_t* req) {
   WriteBaton* baton = static_cast<WriteBaton*>(req->data);
   WaitForSingleObject(baton->hThread, INFINITE);
   CloseHandle(baton->hThread);
-  uv_close((uv_handle_t*)req, AsyncCloseCallback);
+  uv_close(reinterpret_cast<uv_handle_t*>(req), AsyncCloseCallback);
 
   v8::Local<v8::Value> argv[1];
   if (baton->errorString[0]) {
@@ -553,7 +552,7 @@ void EIO_AfterRead(uv_async_t* req) {
   ReadBaton* baton = static_cast<ReadBaton*>(req->data);
   WaitForSingleObject(baton->hThread, INFINITE);
   CloseHandle(baton->hThread);
-  uv_close((uv_handle_t*)req, AsyncCloseCallback);
+  uv_close(reinterpret_cast<uv_handle_t*>(req), AsyncCloseCallback);
 
   v8::Local<v8::Value> argv[2];
   if (baton->errorString[0]) {
@@ -561,7 +560,7 @@ void EIO_AfterRead(uv_async_t* req) {
     argv[1] = Nan::Undefined();
   } else {
     argv[0] = Nan::Null();
-    argv[1] = Nan::New<v8::Integer>((int)baton->bytesRead);
+    argv[1] = Nan::New<v8::Integer>(static_cast<int>(baton->bytesRead));
   }
 
   baton->callback.Call(2, argv);
@@ -588,9 +587,8 @@ void EIO_Close(uv_work_t* req) {
   }
 }
 
-char *copySubstring(char *someString, int n)
-{
-  char *new_ = (char*)malloc(sizeof(char)*n + 1);
+char *copySubstring(char *someString, int n) {
+  char *new_ = reinterpret_cast<char*>(malloc(sizeof(char)*n + 1));
   strncpy_s(new_, n + 1, someString, n);
   new_[n] = '\0';
   return new_;
@@ -604,7 +602,7 @@ NAN_METHOD(List) {
   }
 
   ListBaton* baton = new ListBaton();
-  strcpy(baton->errorString, "");
+  snprintf(baton->errorString, sizeof(baton->errorString), "");
   baton->callback.Reset(info[0].As<v8::Function>());
 
   uv_work_t* req = new uv_work_t();
@@ -615,7 +613,7 @@ NAN_METHOD(List) {
 void EIO_List(uv_work_t* req) {
   ListBaton* data = static_cast<ListBaton*>(req->data);
 
-  GUID *guidDev = (GUID*)& GUID_DEVCLASS_PORTS;
+  GUID *guidDev = (GUID*)& GUID_DEVCLASS_PORTS;  // NOLINT
   HDEVINFO hDevInfo = SetupDiGetClassDevs(guidDev, NULL, NULL, DIGCF_PRESENT | DIGCF_PROFILE);
   SP_DEVINFO_DATA deviceInfoData;
 
@@ -662,10 +660,16 @@ void EIO_List(uv_work_t* req) {
       productId = copySubstring(productId, 4);
     }
 
-    if (SetupDiGetDeviceRegistryProperty(hDevInfo, &deviceInfoData, SPDRP_LOCATION_INFORMATION, &dwPropertyRegDataType, (BYTE*)szBuffer, sizeof(szBuffer), &dwSize)) {
+    if (SetupDiGetDeviceRegistryProperty(hDevInfo, &deviceInfoData,
+                                         SPDRP_LOCATION_INFORMATION, &dwPropertyRegDataType,
+                                         reinterpret_cast<BYTE*>(szBuffer),
+                                         sizeof(szBuffer), &dwSize)) {
       locationId = strdup(szBuffer);
     }
-    if (SetupDiGetDeviceRegistryProperty(hDevInfo, &deviceInfoData, SPDRP_MFG, &dwPropertyRegDataType, (BYTE*)szBuffer, sizeof(szBuffer), &dwSize)) {
+    if (SetupDiGetDeviceRegistryProperty(hDevInfo, &deviceInfoData,
+                                         SPDRP_MFG, &dwPropertyRegDataType,
+                                         reinterpret_cast<BYTE*>(szBuffer),
+                                         sizeof(szBuffer), &dwSize)) {
       manufacturer = strdup(szBuffer);
     }
 


### PR DESCRIPTION
The whitespace fumble at https://github.com/node-serialport/node-serialport/pull/1483/files#r168511525 made me think that `node-serialport` uses `eslint` for linting the javascript code, but doesn't do anything for the c++ code.

This change adds `cc` as a dependency, which in turn runs the [python `cpplint` script](https://pypi.python.org/pypi/cpplint). All of the c++ code, except for some bits in the osx headers, seem to pass the linting.