### PR TITLE
Avoid using deprecated Buffer constructor

### DIFF
--- a/lib/bindings/mock.js
+++ b/lib/bindings/mock.js
@@ -17,7 +17,7 @@ class MockBinding extends BaseBinding {
     this.isOpen = false;
     this.port = null;
     this.lastWrite = null;
-    this.recording = new Buffer(0);
+    this.recording = Buffer.alloc(0);
     this.writeOperation = null; // in flight promise or null
   }
 


### PR DESCRIPTION
`safe-buffer` is already used and provides `Buffer.alloc` polyfill, so just use `Buffer.alloc` directly to avoid hitting deprecated API.

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor

Tracking: https://github.com/nodejs/node/issues/19079