### PR TITLE
baton buffer is now reset after write operations are complete.

### DIFF
--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -388,6 +388,7 @@ void EIO_AfterWrite(uv_async_t* req) {
     argv[0] = Nan::Null();
   }
   baton->callback.Call(1, argv);
+  baton->buffer.Reset();
   delete baton;
 }
 


### PR DESCRIPTION
Resetting the buffer before deleting the struct appears to resolve a memory leak being reported by Windows users.

closes #1496