### PR TITLE
Fix memory leak on Linux/Darwin platforms

### DIFF
--- a/lib/bindings/darwin.js
+++ b/lib/bindings/darwin.js
@@ -47,6 +47,7 @@ class DarwinBinding extends BaseBinding {
       .then(() => {
         const fd = this.fd;
         this.poller.stop();
+        this.poller.destroy();
         this.poller = null;
         this.openOptions = null;
         this.fd = null;

--- a/lib/bindings/linux.js
+++ b/lib/bindings/linux.js
@@ -47,6 +47,7 @@ class LinuxBinding extends BaseBinding {
       .then(() => {
         const fd = this.fd;
         this.poller.stop();
+        this.poller.destroy();
         this.poller = null;
         this.openOptions = null;
         this.fd = null;

--- a/lib/bindings/poller.js
+++ b/lib/bindings/poller.js
@@ -89,6 +89,16 @@ class Poller extends EventEmitter {
   stop() {
     logger('Stopping poller');
     this.poller.stop();
+    this.emitCanceled();
+  }
+
+  destroy() {
+    logger('Destroying poller');
+    this.poller.destroy();
+    this.emitCanceled();
+  }
+
+  emitCanceled() {
     const err = new Error('Canceled');
     err.canceled = true;
     this.emit('readable', err);

--- a/src/poller.cpp
+++ b/src/poller.cpp
@@ -76,6 +76,7 @@ NAN_MODULE_INIT(Poller::Init) {
 
   Nan::SetPrototypeMethod(tpl, "poll", poll);
   Nan::SetPrototypeMethod(tpl, "stop", stop);
+  Nan::SetPrototypeMethod(tpl, "destroy", destroy);
 
   constructor().Reset(Nan::GetFunction(tpl).ToLocalChecked());
   Nan::Set(target, Nan::New("Poller").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
@@ -120,6 +121,12 @@ NAN_METHOD(Poller::poll) {
 NAN_METHOD(Poller::stop) {
   Poller* obj = Nan::ObjectWrap::Unwrap<Poller>(info.Holder());
   obj->stop();
+}
+
+NAN_METHOD(Poller::destroy) {
+  Poller* obj = Nan::ObjectWrap::Unwrap<Poller>(info.Holder());
+  obj->persistent().Reset();
+  delete obj;
 }
 
 inline Nan::Persistent<v8::Function> & Poller::constructor() {

--- a/src/poller.h
+++ b/src/poller.h
@@ -26,6 +26,7 @@ class Poller : public Nan::ObjectWrap {
   static NAN_METHOD(New);
   static NAN_METHOD(poll);
   static NAN_METHOD(stop);
+  static NAN_METHOD(destroy);
   static inline Nan::Persistent<v8::Function> & constructor();
 };
 


### PR DESCRIPTION
Poller should be deleted by WeakCallback (attached during wrapping), but v8 doc state : "There is no guarantee as to when or even if the callback is invoked" and indeed that never happens.

Changes consist code to allow deleting Poller object explicitly from JavaScript.
