### PR TITLE
Put back building on Node 4, 5 and 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,8 @@ env:
   matrix:
   - TRAVIS_NODE_VERSION="4" SKIP_LINT="true"
   - TRAVIS_NODE_VERSION="4" SKIP_LINT="true" ARCH="x86"
-  - TRAVIS_NODE_VERSION="5" SKIP_LINT="true"
-  - TRAVIS_NODE_VERSION="5" SKIP_LINT="true" ARCH="x86"
   - TRAVIS_NODE_VERSION="6"
   - TRAVIS_NODE_VERSION="6" ARCH="x86"
-  - TRAVIS_NODE_VERSION="7"
-  - TRAVIS_NODE_VERSION="7" ARCH="x86"
   - TRAVIS_NODE_VERSION="8"
   - TRAVIS_NODE_VERSION="8" ARCH="x86"
   - TRAVIS_NODE_VERSION="9"
@@ -35,13 +31,9 @@ env:
 matrix:
   exclude:
   - os: osx
-    env: TRAVIS_NODE_VERSION="4" ARCH="x86"
-  - os: osx
-    env: TRAVIS_NODE_VERSION="5" ARCH="x86"
+    env: TRAVIS_NODE_VERSION="4" SKIP_LINT="true" ARCH="x86"
   - os: osx
     env: TRAVIS_NODE_VERSION="6" ARCH="x86"
-  - os: osx
-    env: TRAVIS_NODE_VERSION="7" ARCH="x86"
   - os: osx
     env: TRAVIS_NODE_VERSION="8" ARCH="x86"
   - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,14 @@ env:
   global:
   - secure: "H6kgK5KzVP34pId84/GsnLd6Qb2mwYJ3W4tWurK3QetqVh1kH0qC7LOc6gg9ZTIIu750hZDNofl1h7Ttm2jTzfCtAsPdX3wuuBpIi87ZBZY2fwm6zD1anqF0AdKK9IyKYJaSWFjgNzRvzob6VYWxvYFXaKNT948gseuW/f2uSxI="
   matrix:
+  - TRAVIS_NODE_VERSION="4" SKIP_LINT="true"
+  - TRAVIS_NODE_VERSION="4" SKIP_LINT="true" ARCH="x86"
+  - TRAVIS_NODE_VERSION="5" SKIP_LINT="true"
+  - TRAVIS_NODE_VERSION="5" SKIP_LINT="true" ARCH="x86"
   - TRAVIS_NODE_VERSION="6"
   - TRAVIS_NODE_VERSION="6" ARCH="x86"
+  - TRAVIS_NODE_VERSION="7"
+  - TRAVIS_NODE_VERSION="7" ARCH="x86"
   - TRAVIS_NODE_VERSION="8"
   - TRAVIS_NODE_VERSION="8" ARCH="x86"
   - TRAVIS_NODE_VERSION="9"
@@ -29,7 +35,13 @@ env:
 matrix:
   exclude:
   - os: osx
+    env: TRAVIS_NODE_VERSION="4" ARCH="x86"
+  - os: osx
+    env: TRAVIS_NODE_VERSION="5" ARCH="x86"
+  - os: osx
     env: TRAVIS_NODE_VERSION="6" ARCH="x86"
+  - os: osx
+    env: TRAVIS_NODE_VERSION="7" ARCH="x86"
   - os: osx
     env: TRAVIS_NODE_VERSION="8" ARCH="x86"
   - os: osx
@@ -76,7 +88,7 @@ install:
 - npm install --build-from-source
 
 script:
-- npm run lint
+- if [[ -z "$SKIP_LINT" ]]; then npm run lint; fi
 - node ./
 - npm test
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,10 @@ environment:
     secure: iDcAJCYgJK4tffyzEHbMVR8DatJcIN8eY0h29p9JQkl43TcEcm6Z6JLOBpGDk1MJ
 
   matrix:
+  - nodejs_version: "4"
+  - nodejs_version: "5"
   - nodejs_version: "6"
+  - nodejs_version: "7"
   - nodejs_version: "8"
   - nodejs_version: "9"
   - nodejs_version: "10"
@@ -54,7 +57,9 @@ build_script:
 
 test_script:
 - ps: >
-    npm run lint
+    if ($env:nodejs_version -ge 6 ) {
+      npm run lint;
+    }
     node ./
 
 # If we run npm test in powershell it'll have the wrong encoding so we have to do it like this

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,10 @@ environment:
   - nodejs_version: "9"
   - nodejs_version: "10"
 
+  exclude:
+  - platform: x86
+  - nodejs_version: "4"
+
 platform:
 - x86
 - x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,7 @@ environment:
 
   matrix:
   - nodejs_version: "4"
-  - nodejs_version: "5"
   - nodejs_version: "6"
-  - nodejs_version: "7"
   - nodejs_version: "8"
   - nodejs_version: "9"
   - nodejs_version: "10"


### PR DESCRIPTION
This PR addes Node 4, 5 and 7 to Travis and Appveyor to fix #1588. I assume the change from `prebuild --all` to `prebuild-ci` means that now `serialport` must be built on every major Node version.

Travis builds on Linux and Mac OS: https://travis-ci.org/monkbroc/node-serialport/builds/398921622

Appveyor build on Windows: https://ci.appveyor.com/project/monkbroc/node-serialport/build/1.0.5

Some changes other than the obvious:
- The latest `eslint` tool includes ES6 syntax so it doesn't run on Node 4 and 5. It's OK to skip lint on those versions since lint will run on all other Node versions anyway.
- Currently the Appveyor build for Node 5 on Windows builds due to the redefinition of `__pfnDliNotifyHook2`. I don't know what could cause that as I assume that `serialport` built fine on Appveyor previously.
