### PR TITLE
Add support for beaglebone serial ports.

### DIFF
--- a/lib/bindings/linux-list.js
+++ b/lib/bindings/linux-list.js
@@ -5,7 +5,7 @@ const Readline = require('@serialport/parser-readline');
 
 // get only serial port names
 function checkPathOfDevice(path) {
-  return (/(tty(S|ACM|USB|AMA|MFD)|rfcomm)/).test(path) && path;
+  return (/(tty(S|ACM|USB|AMA|MFD|O)|rfcomm)/).test(path) && path;
 }
 
 function propName(name) {


### PR DESCRIPTION
The Beaglebone's serial ports are enumerated as `/dev/ttyO[0-4]`. Now they can be listed.