### PR TITLE
put back prebuild binary builders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ os:
 - osx
 env:
   global:
-  - secure: "H6kgK5KzVP34pId84/GsnLd6Qb2mwYJ3W4tWurK3QetqVh1kH0qC7LOc6gg9ZTIIu750hZDNofl1h7Ttm2jTzfCtAsPdX3wuuBpIi87ZBZY2fwm6zD1anqF0AdKK9IyKYJaSWFjgNzRvzob6VYWxvYFXaKNT948gseuW/f2uSxI="
+  - secure: "L+AGMJc5NAsuym+xzB4FWj0c2rCobosixkoxLBhDBVkLiYsMtfS9y1w8Xz0pbWKJnJAH9tfwHluu5aX2qYk2HbreSyNzy8hbPW+9RbSyAQexeiZG4mLuDEz0xvlpCCQBsS1OfMypQk0/JvL4oA9B/xasrpkeVuPI7dwAz2WcFms="
   matrix:
   - TRAVIS_NODE_VERSION="6"
   - TRAVIS_NODE_VERSION="6" ARCH="x86"
-  - TRAVIS_NODE_VERSION="8"
-  - TRAVIS_NODE_VERSION="8" ARCH="x86"
+  - BINARY_BUILDER="true" TRAVIS_NODE_VERSION="8"
+  - BINARY_BUILDER="true" TRAVIS_NODE_VERSION="8" ARCH="x86"
   - TRAVIS_NODE_VERSION="9"
   - TRAVIS_NODE_VERSION="9" ARCH="x86"
   - TRAVIS_NODE_VERSION="10"
@@ -31,7 +31,7 @@ matrix:
   - os: osx
     env: TRAVIS_NODE_VERSION="6" ARCH="x86"
   - os: osx
-    env: TRAVIS_NODE_VERSION="8" ARCH="x86"
+    env: BINARY_BUILDER="true" TRAVIS_NODE_VERSION="8" ARCH="x86"
   - os: osx
     env: TRAVIS_NODE_VERSION="9" ARCH="x86"
 
@@ -68,7 +68,7 @@ before_install:
 - PUBLISH_BINARY=false
 - echo $TRAVIS_BRANCH
 - echo `git describe --tags --always HEAD`
-- if [[ $TRAVIS_BRANCH == `git describe --tags --always HEAD` ]]; then PUBLISH_BINARY=true; fi;
+- if [[ $TRAVIS_BRANCH == `git describe --tags --always HEAD` ]]; then PUBLISH_BINARY=$BINARY_BUILDER; fi;
 - echo "Publishing native platform Binary Package? ->" $PUBLISH_BINARY
 
 install:
@@ -84,7 +84,7 @@ script:
 - >
   if [[ $PUBLISH_BINARY == true ]]; then
     echo "building and uploading binaries"
-    npm run prebuild-ci;
+    npm run prebuild-upload;
   fi;
 
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,14 @@
 os: unstable
 environment:
-  PREBUILD_TOKEN:
+  prebuild_upload:
     secure: a/seaM+nUnQWhWUnbyz8fl9vPwuyqDTrFviptDykYp2c46vdTvlAxU6yqD/PpDiI
   COVERALLS_REPO_TOKEN:
     secure: iDcAJCYgJK4tffyzEHbMVR8DatJcIN8eY0h29p9JQkl43TcEcm6Z6JLOBpGDk1MJ
 
   matrix:
   - nodejs_version: "6"
-  - nodejs_version: "8"
+  - binary_builder: "true"
+    nodejs_version: "8"
   - nodejs_version: "9"
   - nodejs_version: "10"
 
@@ -37,7 +38,7 @@ install:
 # then we publish the binaries if tests pass.
 - ps: >
     if ($env:appveyor_repo_tag -match "true" -and ("$(git describe --tags --always HEAD)" -eq $env:appveyor_repo_tag_name)) {
-      $env:publish_binary = "true";
+      $env:publish_binary = $env:binary_builder;
     }
     if ($env:publish_binary -eq "true") {
       "We're publishing a binary!" | Write-Host
@@ -62,8 +63,7 @@ test_script:
 
 - ps: >
     if ($env:publish_binary -eq "true") {
-      "building and uploading binaries" | Write-Host;
-      npm run prebuild-ci;
+      npm run prebuild-upload
     }
     true;
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "modem",
     "nodebots",
     "RFID",
+    "robotics",
     "sensor",
     "serial port",
     "serial",
@@ -85,8 +86,7 @@
     "istanbul": "^0.4.4",
     "jsdoc": "^3.5.5",
     "mocha": "^5.2.0",
-    "prebuild": "^7.6.0",
-    "prebuild-ci": "^2.2.3",
+    "prebuild": "github:reconbot/prebuild#reconbot/build_v8_with_gn",
     "proxyquire": "^2.0.0",
     "sinon": "^6.0.1"
   },
@@ -115,7 +115,7 @@
     "install": "prebuild-install || node-gyp rebuild",
     "rebuild": "prebuild --compile",
     "prebuild": "prebuild --all --strip --verbose",
-    "prebuild-ci": "prebuild-ci"
+    "prebuild-upload": "prebuild --all --strip --verbose"
   },
   "gypfile": true,
   "cc": {


### PR DESCRIPTION
I'll use my branch that fixes `prebuild --all` until it lands and is released.