### PR TITLE
Fixed uninitialized outbaud

### DIFF
--- a/packages/bindings/src/serialport_unix.cpp
+++ b/packages/bindings/src/serialport_unix.cpp
@@ -366,7 +366,7 @@ void EIO_Get(uv_work_t* req) {
 
 void EIO_GetBaudRate(uv_work_t* req) {
   GetBaudRateBaton* data = static_cast<GetBaudRateBaton*>(req->data);
-  int outbaud;
+  int outbaud = -1;
 
   #if defined(__linux__) && defined(ASYNC_SPD_CUST)
   if (-1 == linuxGetSystemBaudRate(data->fd, &outbaud)) {

--- a/packages/bindings/src/serialport_unix.cpp
+++ b/packages/bindings/src/serialport_unix.cpp
@@ -373,11 +373,8 @@ void EIO_GetBaudRate(uv_work_t* req) {
     snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get baud rate", strerror(errno));
     return;
   }
-  #endif
-
-  // TODO(Fumon) implement on mac
-  #if defined(MAC_OS_X_VERSION_10_4) && (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_4)
-  snprintf(data->errorString, sizeof(data->errorString), "Error: System baud rate check not implemented on darwin");
+  #else
+  snprintf(data->errorString, sizeof(data->errorString), "Error: System baud rate check not implemented on this platform");
   return;
   #endif
 


### PR DESCRIPTION
data->baudRate was assigned an unassigned outbaud value.

Another (maybe better) solution would be to give outbaud a default value. should that be 0 or -1 ? Creating this pull request as basis for the discussion