### PR TITLE
add orient xwt-ps050 serialports name prefix

### DIFF
--- a/packages/bindings/lib/linux-list.js
+++ b/packages/bindings/lib/linux-list.js
@@ -3,7 +3,7 @@ const Readline = require('@serialport/parser-readline')
 
 // get only serial port names
 function checkPathOfDevice(path) {
-  return /(tty(S|ACM|USB|AMA|MFD|O)|rfcomm)/.test(path) && path
+  return /(tty(S|WCH|ACM|USB|AMA|MFD|O)|rfcomm)/.test(path) && path
 }
 
 function propName(name) {


### PR DESCRIPTION
Hello!
I work with device orient xwt-ps050 in centos7, and it have "WCH" serialports name prefix.
I found no other way to add it without lost in updates, if it possible to use some public api to change this checkPathOfDevice method tell me.
Thank you!