### PR TITLE
Early write callback for empty buffers

### DIFF
--- a/packages/bindings/lib/bindings-test.js
+++ b/packages/bindings/lib/bindings-test.js
@@ -394,6 +394,11 @@ function testBinding(bindingName, Binding, testPort) {
           const data = Buffer.alloc(1024 * 2)
           return binding.write(data)
         })
+
+        it('resolves after an empty write', () => {
+          const data = Buffer.from([])
+          return binding.write(data)
+        })
       })
 
       describe('#drain', () => {

--- a/packages/bindings/lib/darwin.js
+++ b/packages/bindings/lib/darwin.js
@@ -59,13 +59,16 @@ class DarwinBinding extends AbstractBinding {
   }
 
   write(buffer) {
-    this.writeOperation = super
-      .write(buffer)
-      .then(() => unixWrite.call(this, buffer))
-      .then(() => {
-        this.writeOperation = null
-      })
-    return this.writeOperation
+    if (buffer.length > 0) {
+      this.writeOperation = super
+        .write(buffer)
+        .then(() => unixWrite.call(this, buffer))
+        .then(() => {
+          this.writeOperation = null
+        })
+      return this.writeOperation
+    }
+    return Promise.resolve()
   }
 
   update(options) {

--- a/packages/bindings/lib/linux.js
+++ b/packages/bindings/lib/linux.js
@@ -59,13 +59,16 @@ class LinuxBinding extends AbstractBinding {
   }
 
   write(buffer) {
-    this.writeOperation = super
-      .write(buffer)
-      .then(() => unixWrite.call(this, buffer))
-      .then(() => {
-        this.writeOperation = null
-      })
-    return this.writeOperation
+    if (buffer.length > 0) {
+      this.writeOperation = super
+        .write(buffer)
+        .then(() => unixWrite.call(this, buffer))
+        .then(() => {
+          this.writeOperation = null
+        })
+      return this.writeOperation
+    }
+    return Promise.resolve()
   }
 
   update(options) {

--- a/packages/bindings/lib/win32.js
+++ b/packages/bindings/lib/win32.js
@@ -66,13 +66,16 @@ class WindowsBinding extends AbstractBinding {
   }
 
   write(buffer) {
-    this.writeOperation = super
-      .write(buffer)
-      .then(() => promisify(binding.write)(this.fd, buffer))
-      .then(() => {
-        this.writeOperation = null
-      })
-    return this.writeOperation
+    if (buffer.length > 0) {
+      this.writeOperation = super
+        .write(buffer)
+        .then(() => promisify(binding.write)(this.fd, buffer))
+        .then(() => {
+          this.writeOperation = null
+        })
+      return this.writeOperation
+    }
+    return Promise.resolve()
   }
 
   update(options) {

--- a/packages/stream/stream.test.js
+++ b/packages/stream/stream.test.js
@@ -396,7 +396,7 @@ describe('SerialPort', () => {
       it('converts strings with encodings to buffers', done => {
         const port = new SerialPort('/dev/exists')
         port.on('open', () => {
-          const data = 'COFFEE'
+          const data = 'C0FFEE'
           port.write(data, 'hex', () => {
             const lastWrite = port.binding.lastWrite
             assert.deepEqual(Buffer.from(data, 'hex'), lastWrite)


### PR DESCRIPTION
Fixes #1715 

As discussed with @reconbot, the native bindings for write operations have different behavior for empty buffers. So it's probably better to just callback early and not bother the bindings layer with the empty buffer. 