### PR TITLE
Fix syntax highlighting in docs

### DIFF
--- a/docs/api-binding-abstract.md
+++ b/docs/api-binding-abstract.md
@@ -5,7 +5,7 @@ title: Abstract Binding
 
 Typescript signature of Abstract Binding
 
-```ts
+```typescript
 
 class AbstractBinding {
   static list(): Promise<PortInfo[]>


### PR DESCRIPTION
The code in this block wasn't being highlighted, and in other parts of the doc `typescript` is specified instead of `ts`, so assuming `ts` is a typo stopping it from highlighting properly.