### PR TITLE
Updates for Node v12

### DIFF
--- a/packages/bindings/src/darwin_list.cpp
+++ b/packages/bindings/src/darwin_list.cpp
@@ -349,7 +349,7 @@ void EIO_AfterList(uv_work_t* req) {
     argv[0] = Nan::Null();
     argv[1] = results;
   }
-  data->callback.Call(2, argv);
+  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 2, argv);
 
   for (std::list<ListResultItem*>::iterator it = data->results.begin(); it != data->results.end(); ++it) {
     delete *it;

--- a/packages/bindings/src/poller.cpp
+++ b/packages/bindings/src/poller.cpp
@@ -66,7 +66,7 @@ void Poller::onData(uv_poll_t* handle, int status, int events) {
   int newEvents = obj->events & ~events;
   obj->poll(newEvents);
 
-  obj->callback.Call(2, argv);
+  Nan::Call(obj->callback, Nan::GetCurrentContext()->Global(), 2, argv);
 }
 
 NAN_MODULE_INIT(Poller::Init) {

--- a/packages/bindings/src/serialport.cpp
+++ b/packages/bindings/src/serialport.cpp
@@ -45,7 +45,7 @@ NAN_METHOD(Open) {
     Nan::ThrowTypeError("Second argument must be an object");
     return;
   }
-  v8::Local<v8::Object> options = info[1]->ToObject();
+  v8::Local<v8::Object> options = Nan::To<v8::Object>(info[1]).ToLocalChecked();
 
   // callback
   if (!info[2]->IsFunction()) {
@@ -110,7 +110,7 @@ NAN_METHOD(Update) {
     Nan::ThrowTypeError("Second argument must be an object");
     return;
   }
-  v8::Local<v8::Object> options = info[1]->ToObject();
+  v8::Local<v8::Object> options = Nan::To<v8::Object>(info[1]).ToLocalChecked();
 
   if (!Nan::Has(options, Nan::New<v8::String>("baudRate").ToLocalChecked()).FromMaybe(false)) {
     Nan::ThrowTypeError("\"baudRate\" must be set on options object");
@@ -247,7 +247,7 @@ NAN_METHOD(Set) {
     Nan::ThrowTypeError("Second argument must be an object");
     return;
   }
-  v8::Local<v8::Object> options = info[1]->ToObject();
+  v8::Local<v8::Object> options = Nan::To<v8::Object>(info[1]).ToLocalChecked();
 
   // callback
   if (!info[2]->IsFunction()) {

--- a/packages/bindings/src/serialport.cpp
+++ b/packages/bindings/src/serialport.cpp
@@ -456,30 +456,28 @@ SerialPortStopBits NAN_INLINE(ToStopBitEnum(double stopBits)) {
   return SERIALPORT_STOPBITS_ONE;
 }
 
-extern "C" {
-  void init(v8::Handle<v8::Object> target) {
-    Nan::HandleScope scope;
-    Nan::SetMethod(target, "set", Set);
-    Nan::SetMethod(target, "get", Get);
-    Nan::SetMethod(target, "getBaudRate", GetBaudRate);
-    Nan::SetMethod(target, "open", Open);
-    Nan::SetMethod(target, "update", Update);
-    Nan::SetMethod(target, "close", Close);
-    Nan::SetMethod(target, "flush", Flush);
-    Nan::SetMethod(target, "drain", Drain);
+NAN_MODULE_INIT(init) {
+  Nan::HandleScope scope;
+  Nan::SetMethod(target, "set", Set);
+  Nan::SetMethod(target, "get", Get);
+  Nan::SetMethod(target, "getBaudRate", GetBaudRate);
+  Nan::SetMethod(target, "open", Open);
+  Nan::SetMethod(target, "update", Update);
+  Nan::SetMethod(target, "close", Close);
+  Nan::SetMethod(target, "flush", Flush);
+  Nan::SetMethod(target, "drain", Drain);
 
-    #ifdef __APPLE__
-    Nan::SetMethod(target, "list", List);
-    #endif
+  #ifdef __APPLE__
+  Nan::SetMethod(target, "list", List);
+  #endif
 
-    #ifdef WIN32
-    Nan::SetMethod(target, "write", Write);
-    Nan::SetMethod(target, "read", Read);
-    Nan::SetMethod(target, "list", List);
-    #else
-    Poller::Init(target);
-    #endif
-  }
+  #ifdef WIN32
+  Nan::SetMethod(target, "write", Write);
+  Nan::SetMethod(target, "read", Read);
+  Nan::SetMethod(target, "list", List);
+  #else
+  Poller::Init(target);
+  #endif
 }
 
 NODE_MODULE(serialport, init);

--- a/packages/bindings/src/serialport.cpp
+++ b/packages/bindings/src/serialport.cpp
@@ -38,7 +38,7 @@ NAN_METHOD(Open) {
     Nan::ThrowTypeError("First argument must be a string");
     return;
   }
-  v8::String::Utf8Value path(info[0]->ToString());
+  v8::String::Utf8Value path(Nan::To<v8::String>(info[0]).ToLocalChecked());
 
   // options
   if (!info[1]->IsObject()) {

--- a/packages/bindings/src/serialport.cpp
+++ b/packages/bindings/src/serialport.cpp
@@ -92,7 +92,7 @@ void EIO_AfterOpen(uv_work_t* req) {
     argv[1] = Nan::New<v8::Int32>(data->result);
   }
 
-  data->callback.Call(2, argv);
+  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 2, argv);
   delete data;
   delete req;
 }
@@ -147,7 +147,7 @@ void EIO_AfterUpdate(uv_work_t* req) {
     argv[0] = Nan::Null();
   }
 
-  data->callback.Call(1, argv);
+  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 1, argv);
 
   delete data;
   delete req;
@@ -185,7 +185,7 @@ void EIO_AfterClose(uv_work_t* req) {
   } else {
     argv[0] = Nan::Null();
   }
-  data->callback.Call(1, argv);
+  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 1, argv);
 
   delete data;
   delete req;
@@ -228,7 +228,7 @@ void EIO_AfterFlush(uv_work_t* req) {
     argv[0] = Nan::Null();
   }
 
-  data->callback.Call(1, argv);
+  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 1, argv);
 
   delete data;
   delete req;
@@ -282,7 +282,7 @@ void EIO_AfterSet(uv_work_t* req) {
   } else {
     argv[0] = Nan::Null();
   }
-  data->callback.Call(1, argv);
+  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 1, argv);
 
   delete data;
   delete req;
@@ -333,7 +333,7 @@ void EIO_AfterGet(uv_work_t* req) {
     argv[0] = Nan::Null();
     argv[1] = results;
   }
-  data->callback.Call(2, argv);
+  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 2, argv);
 
   delete data;
   delete req;
@@ -380,7 +380,7 @@ void EIO_AfterGetBaudRate(uv_work_t* req) {
     argv[0] = Nan::Null();
     argv[1] = results;
   }
-  data->callback.Call(2, argv);
+  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 2, argv);
 
   delete data;
   delete req;
@@ -421,7 +421,7 @@ void EIO_AfterDrain(uv_work_t* req) {
   } else {
     argv[0] = Nan::Null();
   }
-  data->callback.Call(1, argv);
+  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 1, argv);
 
   delete data;
   delete req;

--- a/packages/bindings/src/serialport_win.cpp
+++ b/packages/bindings/src/serialport_win.cpp
@@ -301,7 +301,7 @@ NAN_METHOD(Write) {
     Nan::ThrowTypeError("Second argument must be a buffer");
     return;
   }
-  v8::Local<v8::Object> buffer = info[1]->ToObject();
+  v8::Local<v8::Object> buffer = Nan::To<v8::Object>(info[1]).ToLocalChecked();
   char* bufferData = node::Buffer::Data(buffer);
   size_t bufferLength = node::Buffer::Length(buffer);
 
@@ -405,7 +405,7 @@ NAN_METHOD(Read) {
     Nan::ThrowTypeError("Second argument must be a buffer");
     return;
   }
-  v8::Local<v8::Object> buffer = info[1]->ToObject();
+  v8::Local<v8::Object> buffer = Nan::To<v8::Object>(info[1]).ToLocalChecked();
   size_t bufferLength = node::Buffer::Length(buffer);
 
   // offset

--- a/packages/bindings/src/serialport_win.cpp
+++ b/packages/bindings/src/serialport_win.cpp
@@ -387,7 +387,7 @@ void EIO_AfterWrite(uv_async_t* req) {
   } else {
     argv[0] = Nan::Null();
   }
-  baton->callback.Call(1, argv);
+  Nan::Call(baton->callback, Nan::GetCurrentContext()->Global(), 1, argv);
   baton->buffer.Reset();
   delete baton;
 }
@@ -571,7 +571,7 @@ void EIO_AfterRead(uv_async_t* req) {
     argv[1] = Nan::New<v8::Integer>(static_cast<int>(baton->bytesRead));
   }
 
-  baton->callback.Call(2, argv);
+  Nan::Call(baton->callback, Nan::GetCurrentContext()->Global(), 2, argv);
   delete baton;
 }
 
@@ -918,7 +918,7 @@ void EIO_AfterList(uv_work_t* req) {
     argv[0] = Nan::Null();
     argv[1] = results;
   }
-  data->callback.Call(2, argv);
+  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 2, argv);
 
   for (std::list<ListResultItem*>::iterator it = data->results.begin(); it != data->results.end(); ++it) {
     delete *it;


### PR DESCRIPTION
I think this is everything.

The deprecation warnings about `v8::StringObject::New` are pending a new release of Nan and there's nothing to do in this module itself (https://github.com/nodejs/nan/commit/509859cc23b1770376b56550a027840a2ce0f73d#commitcomment-31470115).

(BTW you have a ton of C4312, C4302 and C4311 conversion warnings with MSVC. I can fix those or at least silence the warning if you want in another PR.)

Fixes #1742