### PR TITLE
Bindings: pin `nan` dep to 2.11.1

### DIFF
--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -10,7 +10,7 @@
     "@serialport/parser-readline": "^2.0.2",
     "bindings": "^1.3.0",
     "debug": "^4.1.0",
-    "nan": "^2.11.0",
+    "nan": "2.11.1",
     "prebuild-install": "^5.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #1672 

As explained in [this issue](https://github.com/electron/electron/issues/16120#issuecomment-448136340), there is an Electron 3 node/v8 API mismatch that prevents rebuilding the serialport bindings for electron through `electron-rebuild`. By pinning `nan` to the latest working version (v2.11.1), we can unblock people using electron 3. 

I've confirmed this works locally through the [`electron-serialport` project](https://github.com/johnny-five-io/electron-serialport). 