### PR TITLE
fix: prebuild on mojave

### DIFF
--- a/packages/bindings/binding.gyp
+++ b/packages/bindings/binding.gyp
@@ -29,6 +29,7 @@
             'src/darwin_list.cpp'
           ],
           'xcode_settings': {
+            'MACOSX_DEPLOYMENT_TARGET': '10.9',
             'OTHER_LDFLAGS': [
               '-framework CoreFoundation -framework IOKit'
             ]


### PR DESCRIPTION
OSX Mojave has issues building for node 6. Prebuild tries to build for everything we support and that includes node 6. Node 6 was built with `libstdc++` and osx has (over the past few years, along with nodejs core) moved to `libc++` as the standard library. It no longer supports it with xcode 10 and that's what ships with Mojave.

References
- Workaround until we drop node 6 https://github.com/nodejs/node/pull/23685#issuecomment-430408541
- More background https://github.com/nodejs/node/issues/24648

I reformatted trying to work around this issue. Glad it's solved.