### PR TITLE
fix: propagate async context in callbacks

### DIFF
--- a/packages/bindings/src/darwin_list.cpp
+++ b/packages/bindings/src/darwin_list.cpp
@@ -349,7 +349,7 @@ void EIO_AfterList(uv_work_t* req) {
     argv[0] = Nan::Null();
     argv[1] = results;
   }
-  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 2, argv);
+  data->callback.Call(2, argv, data);
 
   for (std::list<ListResultItem*>::iterator it = data->results.begin(); it != data->results.end(); ++it) {
     delete *it;

--- a/packages/bindings/src/darwin_list.h
+++ b/packages/bindings/src/darwin_list.h
@@ -21,7 +21,8 @@ struct ListResultItem {
   std::string productId;
 };
 
-struct ListBaton {
+struct ListBaton : public Nan::AsyncResource {
+  ListBaton() : AsyncResource("node-serialport:ListBaton"), errorString() {}
   Nan::Callback callback;
   std::list<ListResultItem*> results;
   char errorString[ERROR_STRING_SIZE];

--- a/packages/bindings/src/poller.cpp
+++ b/packages/bindings/src/poller.cpp
@@ -1,7 +1,7 @@
 #include <nan.h>
 #include "./poller.h"
 
-Poller::Poller(int fd) {
+Poller::Poller(int fd) : AsyncResource("node-serialport:poller") {
   Nan::HandleScope scope;
   this->fd = fd;
   this->poll_handle = new uv_poll_t();
@@ -66,7 +66,7 @@ void Poller::onData(uv_poll_t* handle, int status, int events) {
   int newEvents = obj->events & ~events;
   obj->poll(newEvents);
 
-  Nan::Call(obj->callback, Nan::GetCurrentContext()->Global(), 2, argv);
+  obj->callback.Call(2, argv, obj);
 }
 
 NAN_MODULE_INIT(Poller::Init) {

--- a/packages/bindings/src/poller.h
+++ b/packages/bindings/src/poller.h
@@ -3,7 +3,7 @@
 
 #include <nan.h>
 
-class Poller : public Nan::ObjectWrap {
+class Poller : public Nan::ObjectWrap, public Nan::AsyncResource {
  public:
   static NAN_MODULE_INIT(Init);
   static void onData(uv_poll_t* handle, int status, int events);

--- a/packages/bindings/src/serialport.cpp
+++ b/packages/bindings/src/serialport.cpp
@@ -92,7 +92,7 @@ void EIO_AfterOpen(uv_work_t* req) {
     argv[1] = Nan::New<v8::Int32>(data->result);
   }
 
-  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 2, argv);
+  data->callback.Call(2, argv, data);
   delete data;
   delete req;
 }
@@ -147,7 +147,7 @@ void EIO_AfterUpdate(uv_work_t* req) {
     argv[0] = Nan::Null();
   }
 
-  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 1, argv);
+  data->callback.Call(1, argv, data);
 
   delete data;
   delete req;
@@ -185,7 +185,7 @@ void EIO_AfterClose(uv_work_t* req) {
   } else {
     argv[0] = Nan::Null();
   }
-  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 1, argv);
+  data->callback.Call(1, argv, data);
 
   delete data;
   delete req;
@@ -228,7 +228,7 @@ void EIO_AfterFlush(uv_work_t* req) {
     argv[0] = Nan::Null();
   }
 
-  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 1, argv);
+  data->callback.Call(1, argv, data);
 
   delete data;
   delete req;
@@ -282,7 +282,7 @@ void EIO_AfterSet(uv_work_t* req) {
   } else {
     argv[0] = Nan::Null();
   }
-  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 1, argv);
+  data->callback.Call(1, argv, data);
 
   delete data;
   delete req;
@@ -333,7 +333,7 @@ void EIO_AfterGet(uv_work_t* req) {
     argv[0] = Nan::Null();
     argv[1] = results;
   }
-  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 2, argv);
+  data->callback.Call(2, argv, data);
 
   delete data;
   delete req;
@@ -380,7 +380,7 @@ void EIO_AfterGetBaudRate(uv_work_t* req) {
     argv[0] = Nan::Null();
     argv[1] = results;
   }
-  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 2, argv);
+  data->callback.Call(2, argv, data);
 
   delete data;
   delete req;
@@ -421,7 +421,7 @@ void EIO_AfterDrain(uv_work_t* req) {
   } else {
     argv[0] = Nan::Null();
   }
-  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 1, argv);
+  data->callback.Call(1, argv, data);
 
   delete data;
   delete req;

--- a/packages/bindings/src/serialport.h
+++ b/packages/bindings/src/serialport.h
@@ -57,66 +57,75 @@ enum SerialPortStopBits {
 SerialPortParity ToParityEnum(const v8::Local<v8::String>& str);
 SerialPortStopBits ToStopBitEnum(double stopBits);
 
-struct OpenBaton {
+struct OpenBaton : public Nan::AsyncResource {
+  OpenBaton() :
+    AsyncResource("node-serialport:OpenBaton"), errorString(), path() {}
   char errorString[ERROR_STRING_SIZE];
   Nan::Callback callback;
   char path[1024];
-  int fd;
-  int result;
-  int baudRate;
-  int dataBits;
-  bool rtscts;
-  bool xon;
-  bool xoff;
-  bool xany;
-  bool dsrdtr;
-  bool hupcl;
-  bool lock;
+  int fd = 0;
+  int result = 0;
+  int baudRate = 0;
+  int dataBits = 0;
+  bool rtscts = false;
+  bool xon = false;
+  bool xoff = false;
+  bool xany = false;
+  bool dsrdtr = false;
+  bool hupcl = false;
+  bool lock = false;
   SerialPortParity parity;
   SerialPortStopBits stopBits;
 #ifndef WIN32
-  uint8_t vmin;
-  uint8_t vtime;
+  uint8_t vmin = 0;
+  uint8_t vtime = 0;
 #endif
 };
 
-struct ConnectionOptionsBaton {
+struct ConnectionOptionsBaton : public Nan::AsyncResource {
+  ConnectionOptionsBaton() :
+    AsyncResource("node-serialport:ConnectionOptionsBaton"), errorString() {}
   char errorString[ERROR_STRING_SIZE];
   Nan::Callback callback;
-  int fd;
-  int baudRate;
+  int fd = 0;
+  int baudRate = 0;
 };
 
-struct SetBaton {
-  int fd;
+struct SetBaton : public Nan::AsyncResource {
+  SetBaton() : AsyncResource("node-serialport:SetBaton"), errorString() {}
+  int fd = 0;
   Nan::Callback callback;
-  int result;
+  int result = 0;
   char errorString[ERROR_STRING_SIZE];
-  bool rts;
-  bool cts;
-  bool dtr;
-  bool dsr;
-  bool brk;
+  bool rts = false;
+  bool cts = false;
+  bool dtr = false;
+  bool dsr = false;
+  bool brk = false;
 };
 
-struct GetBaton {
-  int fd;
-  Nan::Callback callback;
-  char errorString[ERROR_STRING_SIZE];
-  bool cts;
-  bool dsr;
-  bool dcd;
-};
-
-struct GetBaudRateBaton {
-  int fd;
+struct GetBaton : public Nan::AsyncResource {
+  GetBaton() : AsyncResource("node-serialport:GetBaton"), errorString() {}
+  int fd = 0;
   Nan::Callback callback;
   char errorString[ERROR_STRING_SIZE];
-  int baudRate;
+  bool cts = false;
+  bool dsr = false;
+  bool dcd = false;
 };
 
-struct VoidBaton {
-  int fd;
+struct GetBaudRateBaton : public Nan::AsyncResource {
+  GetBaudRateBaton() :
+    AsyncResource("node-serialport:GetBaudRateBaton"), errorString() {}
+  int fd = 0;
+  Nan::Callback callback;
+  char errorString[ERROR_STRING_SIZE];
+  int baudRate = 0;
+};
+
+struct VoidBaton : public Nan::AsyncResource {
+  VoidBaton() : AsyncResource("node-serialport:VoidBaton"), errorString() {}
+  int fd = 0;
   Nan::Callback callback;
   char errorString[ERROR_STRING_SIZE];
 };

--- a/packages/bindings/src/serialport_win.cpp
+++ b/packages/bindings/src/serialport_win.cpp
@@ -387,7 +387,7 @@ void EIO_AfterWrite(uv_async_t* req) {
   } else {
     argv[0] = Nan::Null();
   }
-  Nan::Call(baton->callback, Nan::GetCurrentContext()->Global(), 1, argv);
+  baton->callback.Call(1, argv, baton);
   baton->buffer.Reset();
   delete baton;
 }
@@ -571,7 +571,7 @@ void EIO_AfterRead(uv_async_t* req) {
     argv[1] = Nan::New<v8::Integer>(static_cast<int>(baton->bytesRead));
   }
 
-  Nan::Call(baton->callback, Nan::GetCurrentContext()->Global(), 2, argv);
+  baton->callback.Call(2, argv, baton);
   delete baton;
 }
 
@@ -918,7 +918,7 @@ void EIO_AfterList(uv_work_t* req) {
     argv[0] = Nan::Null();
     argv[1] = results;
   }
-  Nan::Call(data->callback, Nan::GetCurrentContext()->Global(), 2, argv);
+  data->callback.Call(2, argv, data);
 
   for (std::list<ListResultItem*>::iterator it = data->results.begin(); it != data->results.end(); ++it) {
     delete *it;

--- a/packages/bindings/src/serialport_win.h
+++ b/packages/bindings/src/serialport_win.h
@@ -9,17 +9,18 @@
 
 #define ERROR_STRING_SIZE 1024
 
-struct WriteBaton {
-  int fd;
-  char* bufferData;
-  size_t bufferLength;
-  size_t offset;
-  size_t bytesWritten;
-  void* hThread;
-  bool complete;
+struct WriteBaton : public Nan::AsyncResource {
+  WriteBaton() : AsyncResource("node-serialport:WriteBaton"), bufferData(), errorString() {}
+  int fd = 0;
+  char* bufferData = nullptr;
+  size_t bufferLength = 0;
+  size_t offset = 0;
+  size_t bytesWritten = 0;
+  void* hThread = nullptr;
+  bool complete = false;
   Nan::Persistent<v8::Object> buffer;
   Nan::Callback callback;
-  int result;
+  int result = 0;
   char errorString[ERROR_STRING_SIZE];
 };
 
@@ -29,15 +30,16 @@ void EIO_AfterWrite(uv_async_t* req);
 DWORD __stdcall WriteThread(LPVOID param);
 
 
-struct ReadBaton {
-  int fd;
-  char* bufferData;
-  size_t bufferLength;
-  size_t bytesRead;
-  size_t bytesToRead;
-  size_t offset;
-  void* hThread;
-  bool complete;
+struct ReadBaton : public Nan::AsyncResource {
+  ReadBaton() : AsyncResource("node-serialport:ReadBaton"), errorString() {}
+  int fd = 0;
+  char* bufferData = nullptr;
+  size_t bufferLength = 0;
+  size_t bytesRead = 0;
+  size_t bytesToRead = 0;
+  size_t offset = 0;
+  void* hThread = nullptr;
+  bool complete = false;
   char errorString[ERROR_STRING_SIZE];
   Nan::Callback callback;
 };
@@ -62,10 +64,11 @@ struct ListResultItem {
   std::string productId;
 };
 
-struct ListBaton {
+struct ListBaton : public Nan::AsyncResource {
+  ListBaton() : AsyncResource("node-serialport:ListBaton") {}
   Nan::Callback callback;
   std::list<ListResultItem*> results;
-  char errorString[ERROR_STRING_SIZE];
+  char errorString[ERROR_STRING_SIZE] = "";
 };
 
 #endif  // PACKAGES_SERIALPORT_SRC_SERIALPORT_WIN_H_


### PR DESCRIPTION
Fixes #1751 

I've tested this on Windows with real hardware (repro'ed the issue in #1751). I can't get [WSL](https://docs.microsoft.com/en-us/windows/wsl/faq) to work with a serial port right now to test on Ubuntu.

I can't think of a good way to make this commit smaller. `AsyncResource` needs to be constructed with a `const char*` name unique to each of your `struct`s (so can't inherit from some other class that extends `AsyncResource`). Constructing the `AsyncResource` (in a ctor or initializer list) makes it necessary to initialize everything else that you were relying on value-initialization for. Rather than only initializing the members that you're not setting where the structs are used, I went with the safer option of initializing (almost) everything explicitly. Using more C++ features (`std::string`s) would shorten the code overall (possibly making initialization unnecessary) but would make this commit even bigger. /ramble