### PR TITLE
Change signature of setBaudRate to avoid creating new baton

### DIFF
--- a/packages/bindings/src/serialport.h
+++ b/packages/bindings/src/serialport.h
@@ -131,5 +131,4 @@ struct VoidBaton : public Nan::AsyncResource {
 };
 
 int setup(int fd, OpenBaton *data);
-int setBaudRate(ConnectionOptionsBaton *data);
 #endif  // PACKAGES_SERIALPORT_SRC_SERIALPORT_H_


### PR DESCRIPTION
This is an alternative to #1772 that fixes #1771. I don't have a linux box handy to test this with, fyi.

In a moment I'll open another PR that uses `std::string` instead for comparison.