### PR TITLE
Removed PURGE_RXABORT flag on flush for Windows

### DIFF
--- a/packages/bindings/src/serialport_win.cpp
+++ b/packages/bindings/src/serialport_win.cpp
@@ -935,7 +935,7 @@ void EIO_AfterList(uv_work_t* req) {
 void EIO_Flush(uv_work_t* req) {
   VoidBaton* data = static_cast<VoidBaton*>(req->data);
 
-  DWORD purge_all = PURGE_RXABORT | PURGE_RXCLEAR | PURGE_TXABORT | PURGE_TXCLEAR;
+  DWORD purge_all = PURGE_RXCLEAR | PURGE_TXABORT | PURGE_TXCLEAR;
   if (!PurgeComm(int2handle(data->fd), purge_all)) {
     ErrorCodeToString("Flushing connection (PurgeComm)", GetLastError(), data->errorString);
     return;


### PR DESCRIPTION
The PURGE_RXABORT flag causes the ReadFileEx to be cancelled, which somehow causes the port to become disconnected (didn't dive that deep into the intricacies of the issue).

After creating this fix, we found issue #1013, which suggests the same resolution; after reviewing PR #1223, I'm not sure that #1013 was ever resolved correctly. 

This resolves #1409.