### PR TITLE
binding-mock: allow setting manufacturer and vendor/product ID

### DIFF
--- a/packages/binding-mock/binding-mock.js
+++ b/packages/binding-mock/binding-mock.js
@@ -35,6 +35,9 @@ class MockBinding extends AbstractBinding {
         echo: false,
         record: false,
         readyData: Buffer.from('READY'),
+        manufacturer: 'The J5 Robotics Company',
+        vendorId: undefined,
+        productId: undefined,
       },
       opt
     )
@@ -46,12 +49,12 @@ class MockBinding extends AbstractBinding {
       readyData: Buffer.from(opt.readyData),
       info: {
         comName: path,
-        manufacturer: 'The J5 Robotics Company',
+        manufacturer: opt.manufacturer,
         serialNumber,
         pnpId: undefined,
         locationId: undefined,
-        vendorId: undefined,
-        productId: undefined,
+        vendorId: opt.vendorId,
+        productId: opt.productId,
       },
     }
     debug(serialNumber, 'created port', JSON.stringify({ path, opt }))


### PR DESCRIPTION
This allows setting the manufacturer string and vendor/product IDs of a mock serial port.

My use-case is that my app auto-detects a serial port based on the manufacturer string, and I'd like to be able to test this functionality. I'm currently doing so by `(await SerialPort.list())[0].manufacturer = "..."`, which is ... hacky :)