### PR TITLE
fix: prevent compilation error on Node 12 (ref #1742)

### DIFF
--- a/packages/bindings/src/serialport.cpp
+++ b/packages/bindings/src/serialport.cpp
@@ -38,7 +38,7 @@ NAN_METHOD(Open) {
     Nan::ThrowTypeError("First argument must be a string");
     return;
   }
-  v8::String::Utf8Value path(Nan::To<v8::String>(info[0]).ToLocalChecked());
+  Nan::Utf8String path(info[0]);
 
   // options
   if (!info[1]->IsObject()) {


### PR DESCRIPTION
I think this fixes a slight oversight that prevents it from building against node v12.x but would appreciate review from someone more familiar with nan, v8, etc.

---
Without this, attempting to build against Node v12.0.0 on Linux leads to the below error:
```
../src/serialport.cpp: In function ‘Nan::NAN_METHOD_RETURN_TYPE Open(Nan::NAN_METHOD_ARGS_TYPE)’:
../src/serialport.cpp:41:75: error: no matching function for call to ‘v8::String::Utf8Value::Utf8Value(v8::Local<v8::String>)’
   v8::String::Utf8Value path(Nan::To<v8::String>(info[0]).ToLocalChecked());
                                                                           ^
In file included from /home/user/.node-gyp/12.0.0/include/node/node.h:63:0,
                 from ../node_modules/nan/nan.h:53,
                 from ../src/./serialport.h:6,
                 from ../src/serialport.cpp:1:
/home/user/.node-gyp/12.0.0/include/node/v8.h:2995:5: note: candidate: v8::String::Utf8Value::Utf8Value(v8::Isolate*, v8::Local<v8::Value>)
     Utf8Value(Isolate* isolate, Local<v8::Value> obj);
     ^~~~~~~~~
/home/user/.node-gyp/12.0.0/include/node/v8.h:2995:5: note:   candidate expects 2 arguments, 1 provided
```

And attempting to build again Node v10.15.3 on Linux leads to the below warning:
```
../src/serialport.cpp:41:75: warning: ‘v8::String::Utf8Value::Utf8Value(v8::Local<v8::Value>)’ is deprecated: Use Isolate version [-Wdeprecated-declarations]
@serialport/bindings:    v8::String::Utf8Value path(Nan::To<v8::String>(info[0]).ToLocalChecked());
@serialport/bindings:                                                                            ^
@serialport/bindings: In file included from /home/user/.node-gyp/10.15.3/include/node/v8.h:26:0,
@serialport/bindings:                  from /home/user/.node-gyp/10.15.3/include/node/node.h:63,
@serialport/bindings:                  from ../node_modules/nan/nan.h:53,
@serialport/bindings:                  from ../src/./serialport.h:6,
@serialport/bindings:                  from ../src/serialport.cpp:1:
@serialport/bindings: /home/user/.node-gyp/10.15.3/include/node/v8.h:2892:28: note: declared here
@serialport/bindings:                    explicit Utf8Value(Local<v8::Value> obj));
```