### PR TITLE
chore: rename comName to path

### DIFF
--- a/bin/find-arduino.js
+++ b/bin/find-arduino.js
@@ -1,15 +1,13 @@
 #!/usr/bin/env node
 
-
 // outputs the path to an Arduino to stdout or an error to stderror
 
-const SerialPort = require('../packages/serialport');
-SerialPort.list()
-  .then(ports => {
-    const port = ports.find(port => /arduino/i.test(port.manufacturer));
-    if (!port) {
-      console.error('Arduino Not found');
-      process.exit(1);
-    }
-    console.log(port.comName);
-  });
+const SerialPort = require('../packages/serialport')
+SerialPort.list().then(ports => {
+  const port = ports.find(port => /arduino/i.test(port.manufacturer))
+  if (!port) {
+    console.error('Arduino Not found')
+    process.exit(1)
+  }
+  console.log(port.path)
+})

--- a/bin/write-a-lot.js
+++ b/bin/write-a-lot.js
@@ -1,45 +1,50 @@
 #!/usr/bin/env node
 
-process.env.DEBUG = '*';
-const SerialPort = require('../packages/serialport');
+process.env.DEBUG = '*'
+const SerialPort = require('../packages/serialport')
 
 // outputs the path to an arduino or nothing
 function findArduino() {
   return new Promise((resolve, reject) => {
     if (process.argv[2]) {
-      return resolve(process.argv[2]);
+      return resolve(process.argv[2])
     }
     SerialPort.list((err, ports) => {
-      if (err) { return reject(err) }
-      let resolved = false;
-      ports.forEach((port) => {
-        if (!resolved && /arduino/i.test(port.manufacturer)) {
-          resolved = true;
-          return resolve(port.comName);
-        }
-      });
-      if (!resolved) {
-        reject(new Error('No arduinos found'));
+      if (err) {
+        return reject(err)
       }
-    });
-  });
+      let resolved = false
+      ports.forEach(port => {
+        if (!resolved && /arduino/i.test(port.manufacturer)) {
+          resolved = true
+          return resolve(port.path)
+        }
+      })
+      if (!resolved) {
+        reject(new Error('No arduinos found'))
+      }
+    })
+  })
 }
 
-findArduino().then((portName) => {
-  const port = new SerialPort(portName);
-  port.on('open', () => {
-    console.log('opened', portName);
-    // port.write(Buffer.alloc(1024 * 20, 0));
-    port.on('data', data => console.log('data', data.toString())); // put the port into flowing mode
-    // setTimeout(() => {
-    //   console.log('closing');
-    //   port.close((err) => {
-    //     console.log('closed?', err);
-    //   });
-    // }, 5000);
-  });
-}, () => {
-  console.log('no arduino');
-});
+findArduino().then(
+  portName => {
+    const port = new SerialPort(portName)
+    port.on('open', () => {
+      console.log('opened', portName)
+      // port.write(Buffer.alloc(1024 * 20, 0));
+      port.on('data', data => console.log('data', data.toString())) // put the port into flowing mode
+      // setTimeout(() => {
+      //   console.log('closing');
+      //   port.close((err) => {
+      //     console.log('closed?', err);
+      //   });
+      // }, 5000);
+    })
+  },
+  () => {
+    console.log('no arduino')
+  }
+)
 
-process.on('unhandledRejection', r => console.log(r, r.stack));
+process.on('unhandledRejection', r => console.log(r, r.stack))

--- a/docs/api-stream.md
+++ b/docs/api-stream.md
@@ -77,16 +77,18 @@ If you're using the `serialport` package this defaults to `require('@serialport/
 ```typescript
 SerialPort.list(): Promise<PortInfo[]>
 ```
-Retrieves a list of available serial ports with metadata. Only the `comName` is guaranteed. If unavailable the other fields will be undefined. The `comName` is either the path or an identifier (eg `COM1`) used to open the SerialPort.
+Retrieves a list of available serial ports with metadata. Only the `path` is guaranteed. If unavailable the other fields will be undefined. The `path` is either the path or an identifier (eg `COM1`) used to open the SerialPort.
 
 The `SerialPort` class delegates this function to the provided `Binding` on [`SerialPort.Binding`](#serialportbinding-binding).
 
 We make an effort to identify the hardware attached and have consistent results between systems. Linux and OS X are mostly consistent. Windows relies on 3rd party device drivers for the information and is unable to guarantee the information. On windows If you have a USB connected device can we provide a serial number otherwise it will be `undefined`. The `pnpId` and `locationId` are not the same or present on all systems. The examples below were run with the same Arduino Uno.
 
+__Note__: In `serialport@8` and `@serialport/bindings@3` We renamed `PortInfo.comName` to `PortInfo.path` if you use comName you'll get a warning until the next major release.
+
 ```js
 // OSX example port
 {
-  comName: '/dev/tty.usbmodem1421',
+  path: '/dev/tty.usbmodem1421',
   manufacturer: 'Arduino (www.arduino.cc)',
   serialNumber: '752303138333518011C1',
   pnpId: undefined,
@@ -97,7 +99,7 @@ We make an effort to identify the hardware attached and have consistent results 
 
 // Linux example port
 {
-  comName: '/dev/ttyACM0',
+  path: '/dev/ttyACM0',
   manufacturer: 'Arduino (www.arduino.cc)',
   serialNumber: '752303138333518011C1',
   pnpId: 'usb-Arduino__www.arduino.cc__0043_752303138333518011C1-if00',
@@ -108,7 +110,7 @@ We make an effort to identify the hardware attached and have consistent results 
 
 // Windows example port
 {
-  comName: 'COM3',
+  path: 'COM3',
   manufacturer: 'Arduino LLC (www.arduino.cc)',
   serialNumber: '752303138333518011C1',
   pnpId: 'USB\\VID_2341&PID_0043\\752303138333518011C1',

--- a/docs/guide-cli.md
+++ b/docs/guide-cli.md
@@ -52,11 +52,11 @@ $ serialport-list
 /dev/tty.usbmodem1421    Arduino (www.arduino.cc)
 
 $ serialport-list -f json
-[{"comName":"/dev/tty.Bluetooth-Incoming-Port"},{"comName":"/dev/tty.usbmodem1421","manufacturer":"Arduino (www.arduino.cc)","serialNumber":"752303138333518011C1","locationId":"14200000","vendorId":"2341","productId":"0043"}]
+[{"path":"/dev/tty.Bluetooth-Incoming-Port"},{"path":"/dev/tty.usbmodem1421","manufacturer":"Arduino (www.arduino.cc)","serialNumber":"752303138333518011C1","locationId":"14200000","vendorId":"2341","productId":"0043"}]
 
 $ serialport-list -f jsonline
-{"comName":"/dev/tty.Bluetooth-Incoming-Port"}
-{"comName":"/dev/tty.usbmodem1421","manufacturer":"Arduino (www.arduino.cc)","serialNumber":"752303138333518011C1","locationId":"14200000","vendorId":"2341","productId":"0043"}
+{"path":"/dev/tty.Bluetooth-Incoming-Port"}
+{"path":"/dev/tty.usbmodem1421","manufacturer":"Arduino (www.arduino.cc)","serialNumber":"752303138333518011C1","locationId":"14200000","vendorId":"2341","productId":"0043"}
 ```
 
 ## SerialPort Repl
@@ -83,7 +83,7 @@ port = SerialPort("/dev/tty.usbmodem1421", { autoOpen: false })
 globals { SerialPort, portName, port }
 > SerialPort.list()
   serialport:main .list +6s
-[ { comName: '/dev/tty.usbmodem1421',
+[ { path: '/dev/tty.usbmodem1421',
     manufacturer: 'Arduino (www.arduino.cc)',
     serialNumber: '752303138333518011C1',
     pnpId: undefined,

--- a/packages/binding-abstract/binding-abstract.js
+++ b/packages/binding-abstract/binding-abstract.js
@@ -22,7 +22,7 @@ const debug = require('debug')('serialport/binding-abstract')
  */
 class AbstractBinding {
   /**
-   * Retrieves a list of available serial ports with metadata. The `comName` must be guaranteed, and all other fields should be undefined if unavailable. The `comName` is either the path or an identifier (eg `COM1`) used to open the serialport.
+   * Retrieves a list of available serial ports with metadata. The `path` must be guaranteed, and all other fields should be undefined if unavailable. The `path` is either the path or an identifier (eg `COM1`) used to open the serialport.
    * @returns {Promise} resolves to an array of port [info objects](#module_serialport--SerialPort.list).
    */
   static async list() {

--- a/packages/binding-mock/binding-mock.js
+++ b/packages/binding-mock/binding-mock.js
@@ -1,5 +1,6 @@
 const AbstractBinding = require('@serialport/binding-abstract')
 const debug = require('debug')('serialport/binding-mock')
+const { wrapWithHiddenComName } = require('./legacy')
 
 let ports = {}
 let serialNumber = 0
@@ -46,7 +47,7 @@ class MockBinding extends AbstractBinding {
       record: opt.record,
       readyData: Buffer.from(opt.readyData),
       info: {
-        comName: path,
+        path,
         manufacturer: opt.manufacturer,
         serialNumber,
         pnpId: undefined,
@@ -59,7 +60,7 @@ class MockBinding extends AbstractBinding {
   }
 
   static async list() {
-    return Object.values(ports).map(port => port.info)
+    return wrapWithHiddenComName(Object.values(ports).map(port => port.info))
   }
 
   // Emit data on a mock port

--- a/packages/binding-mock/legacy.js
+++ b/packages/binding-mock/legacy.js
@@ -1,0 +1,26 @@
+let warningSent = false
+
+const wrapWithHiddenComName = async portsPromise => {
+  const ports = await portsPromise
+  return ports.map(port => {
+    const newPort = { ...port }
+    return Object.defineProperties(newPort, {
+      comName: {
+        get() {
+          if (!warningSent) {
+            warningSent = true
+            console.warn(
+              `"PortInfo.comName" has been deprecated. You should now use "PortInfo.path". The property will be removed in the next major release.`
+            )
+          }
+          return newPort.path
+        },
+        enumerable: false,
+      },
+    })
+  })
+}
+
+module.exports = {
+  wrapWithHiddenComName,
+}

--- a/packages/bindings/lib/bindings-test.js
+++ b/packages/bindings/lib/bindings-test.js
@@ -30,7 +30,7 @@ const defaultSetFlags = Object.freeze({
   rts: true,
 })
 
-const listFields = ['comName', 'manufacturer', 'serialNumber', 'pnpId', 'locationId', 'vendorId', 'productId']
+const listFields = ['path', 'manufacturer', 'serialNumber', 'pnpId', 'locationId', 'vendorId', 'productId']
 
 const bindingsToTest = ['mock', platform]
 
@@ -88,6 +88,7 @@ function testBinding(bindingName, Binding, testPort) {
                 assert.notEqual(port[key], '', 'empty values should be undefined')
                 assert.isNotNull(port[key], 'empty values should be undefined')
               })
+              assert.equal(port.comName, port.path)
             })
           })
         })

--- a/packages/bindings/lib/darwin.js
+++ b/packages/bindings/lib/darwin.js
@@ -4,6 +4,7 @@ const AbstractBinding = require('@serialport/binding-abstract')
 const Poller = require('./poller')
 const unixRead = require('./unix-read')
 const unixWrite = require('./unix-write')
+const { wrapWithHiddenComName } = require('./legacy')
 
 const defaultBindingOptions = Object.freeze({
   vmin: 1,
@@ -25,7 +26,7 @@ const asyncFlush = promisify(binding.flush)
  */
 class DarwinBinding extends AbstractBinding {
   static list() {
-    return asyncList()
+    return wrapWithHiddenComName(asyncList())
   }
 
   constructor(opt) {

--- a/packages/bindings/lib/legacy.js
+++ b/packages/bindings/lib/legacy.js
@@ -1,0 +1,26 @@
+const warningSent = false
+
+const wrapWithHiddenComName = async portsPromise => {
+  const ports = await portsPromise
+  return ports.map(port => {
+    const newPort = { ...port }
+    return Object.defineProperties(newPort, {
+      comName: {
+        get() {
+          if (!warningSent) {
+            warningSent = true
+            console.warn(
+              `"PortInfo.comName" has been deprecated. You should now use "PortInfo.path". The property will be removed in the next major release.`
+            )
+          }
+          return newPort.path
+        },
+        enumerable: false,
+      },
+    })
+  })
+}
+
+module.exports = {
+  wrapWithHiddenComName,
+}

--- a/packages/bindings/lib/linux-list-test.js
+++ b/packages/bindings/lib/linux-list-test.js
@@ -75,13 +75,13 @@ N: ttyNOTASERIALPORT
 
 const portOutput = [
   {
-    comName: '/dev/ttyS0',
+    path: '/dev/ttyS0',
   },
   {
-    comName: '/dev/ttyS1',
+    path: '/dev/ttyS1',
   },
   {
-    comName: '/dev/ttyACM0',
+    path: '/dev/ttyACM0',
     manufacturer: 'Arduino (www.arduino.cc)',
     serialNumber: '752303138333518011C1',
     productId: '0043',
@@ -89,16 +89,16 @@ const portOutput = [
     pnpId: 'usb-Arduino__www.arduino.cc__0043_752303138333518011C1-if00',
   },
   {
-    comName: '/dev/ttyAMA_im_a_programmer',
+    path: '/dev/ttyAMA_im_a_programmer',
     pnpId: 'pci-NATA_Siolynx2_C8T6VI1F-if00-port0',
   },
   {
-    comName: '/dev/ttyMFD0',
+    path: '/dev/ttyMFD0',
     vendorId: '2343',
     productId: '0043',
   },
   {
-    comName: '/dev/rfcomm4',
+    path: '/dev/rfcomm4',
   },
 ]
 

--- a/packages/bindings/lib/linux-list.js
+++ b/packages/bindings/lib/linux-list.js
@@ -8,7 +8,7 @@ function checkPathOfDevice(path) {
 
 function propName(name) {
   return {
-    DEVNAME: 'comName',
+    DEVNAME: 'path',
     ID_VENDOR_ENC: 'manufacturer',
     ID_SERIAL_SHORT: 'serialNumber',
     ID_VENDOR_ID: 'vendorId',

--- a/packages/bindings/lib/linux.js
+++ b/packages/bindings/lib/linux.js
@@ -5,6 +5,7 @@ const linuxList = require('./linux-list')
 const Poller = require('./poller')
 const unixRead = require('./unix-read')
 const unixWrite = require('./unix-write')
+const { wrapWithHiddenComName } = require('./legacy')
 
 const defaultBindingOptions = Object.freeze({
   vmin: 1,
@@ -25,7 +26,7 @@ const asyncFlush = promisify(binding.flush)
  */
 class LinuxBinding extends AbstractBinding {
   static list() {
-    return linuxList()
+    return wrapWithHiddenComName(linuxList())
   }
 
   constructor(opt) {

--- a/packages/bindings/lib/win32.js
+++ b/packages/bindings/lib/win32.js
@@ -13,6 +13,7 @@ const asyncGet = promisify(binding.get)
 const asyncGetBaudRate = promisify(binding.getBaudRate)
 const asyncDrain = promisify(binding.drain)
 const asyncFlush = promisify(binding.flush)
+const { wrapWithHiddenComName } = require('./legacy')
 
 /**
  * The Windows binding layer
@@ -21,18 +22,20 @@ class WindowsBinding extends AbstractBinding {
   static async list() {
     const ports = await asyncList()
     // Grab the serial number from the pnp id
-    return ports.map(port => {
-      if (port.pnpId && !port.serialNumber) {
-        const serialNumber = serialNumParser(port.pnpId)
-        if (serialNumber) {
-          return {
-            ...port,
-            serialNumber,
+    return wrapWithHiddenComName(
+      ports.map(port => {
+        if (port.pnpId && !port.serialNumber) {
+          const serialNumber = serialNumParser(port.pnpId)
+          if (serialNumber) {
+            return {
+              ...port,
+              serialNumber,
+            }
           }
         }
-      }
-      return port
-    })
+        return port
+      })
+    )
   }
 
   constructor(opt) {

--- a/packages/bindings/src/darwin_list.cpp
+++ b/packages/bindings/src/darwin_list.cpp
@@ -291,7 +291,7 @@ void EIO_List(uv_work_t* req) {
       stSerialDevice device = (* next).value;
 
       ListResultItem* resultItem = new ListResultItem();
-      resultItem->comName = device.port;
+      resultItem->path = device.port;
 
       if (*device.locationId) {
         resultItem->locationId = device.locationId;
@@ -336,7 +336,7 @@ void EIO_AfterList(uv_work_t* req) {
     for (std::list<ListResultItem*>::iterator it = data->results.begin(); it != data->results.end(); ++it, i++) {
       v8::Local<v8::Object> item = Nan::New<v8::Object>();
 
-      setIfNotEmpty(item, "comName", (*it)->comName.c_str());
+      setIfNotEmpty(item, "path", (*it)->path.c_str());
       setIfNotEmpty(item, "manufacturer", (*it)->manufacturer.c_str());
       setIfNotEmpty(item, "serialNumber", (*it)->serialNumber.c_str());
       setIfNotEmpty(item, "pnpId", (*it)->pnpId.c_str());

--- a/packages/bindings/src/darwin_list.h
+++ b/packages/bindings/src/darwin_list.h
@@ -12,7 +12,7 @@ void EIO_List(uv_work_t* req);
 void EIO_AfterList(uv_work_t* req);
 
 struct ListResultItem {
-  std::string comName;
+  std::string path;
   std::string manufacturer;
   std::string serialNumber;
   std::string pnpId;

--- a/packages/bindings/src/serialport_win.cpp
+++ b/packages/bindings/src/serialport_win.cpp
@@ -855,7 +855,7 @@ void EIO_List(uv_work_t* req) {
     }
     if (isCom) {
       ListResultItem* resultItem = new ListResultItem();
-      resultItem->comName = name;
+      resultItem->path = name;
       resultItem->manufacturer = manufacturer;
       resultItem->pnpId = pnpId;
       if (vendorId) {
@@ -909,7 +909,7 @@ void EIO_AfterList(uv_work_t* req) {
     for (std::list<ListResultItem*>::iterator it = data->results.begin(); it != data->results.end(); ++it, i++) {
       v8::Local<v8::Object> item = Nan::New<v8::Object>();
 
-      setIfNotEmpty(item, "comName", (*it)->comName.c_str());
+      setIfNotEmpty(item, "path", (*it)->path.c_str());
       setIfNotEmpty(item, "manufacturer", (*it)->manufacturer.c_str());
       setIfNotEmpty(item, "serialNumber", (*it)->serialNumber.c_str());
       setIfNotEmpty(item, "pnpId", (*it)->pnpId.c_str());

--- a/packages/bindings/src/serialport_win.h
+++ b/packages/bindings/src/serialport_win.h
@@ -55,7 +55,7 @@ void EIO_List(uv_work_t* req);
 void EIO_AfterList(uv_work_t* req);
 
 struct ListResultItem {
-  std::string comName;
+  std::string path;
   std::string manufacturer;
   std::string serialNumber;
   std::string pnpId;

--- a/packages/list/README.md
+++ b/packages/list/README.md
@@ -28,9 +28,9 @@ $ serialport-list
 /dev/tty.usbmodem1421    Arduino (www.arduino.cc)
 
 $ serialport-list -f json
-[{"comName":"/dev/tty.Bluetooth-Incoming-Port"},{"comName":"/dev/tty.usbmodem1421","manufacturer":"Arduino (www.arduino.cc)","serialNumber":"752303138333518011C1","locationId":"14200000","vendorId":"2341","productId":"0043"}]
+[{"path":"/dev/tty.Bluetooth-Incoming-Port"},{"path":"/dev/tty.usbmodem1421","manufacturer":"Arduino (www.arduino.cc)","serialNumber":"752303138333518011C1","locationId":"14200000","vendorId":"2341","productId":"0043"}]
 
 $ serialport-list -f jsonline
-{"comName":"/dev/tty.Bluetooth-Incoming-Port"}
-{"comName":"/dev/tty.usbmodem1421","manufacturer":"Arduino (www.arduino.cc)","serialNumber":"752303138333518011C1","locationId":"14200000","vendorId":"2341","productId":"0043"}
+{"path":"/dev/tty.Bluetooth-Incoming-Port"}
+{"path":"/dev/tty.usbmodem1421","manufacturer":"Arduino (www.arduino.cc)","serialNumber":"752303138333518011C1","locationId":"14200000","vendorId":"2341","productId":"0043"}
 ```

--- a/packages/list/lib/list.js
+++ b/packages/list/lib/list.js
@@ -19,7 +19,7 @@ function jsonl(ports) {
 const formatters = {
   text(ports) {
     ports.forEach(port => {
-      console.log(`${port.comName}\t${port.pnpId || ''}\t${port.manufacturer || ''}`)
+      console.log(`${port.path}\t${port.pnpId || ''}\t${port.manufacturer || ''}`)
     })
   },
   json(ports) {

--- a/packages/repl/lib/repl.js
+++ b/packages/repl/lib/repl.js
@@ -21,7 +21,7 @@ function findArduino() {
       ports.forEach(port => {
         if (!resolved && /arduino/i.test(port.manufacturer)) {
           resolved = true
-          return resolve(port.comName)
+          return resolve(port.path)
         }
       })
       if (!resolved) {

--- a/packages/serialport/test-manual/many-writes.js
+++ b/packages/serialport/test-manual/many-writes.js
@@ -16,7 +16,7 @@ function findArduino() {
       ports.forEach((port) => {
         if (!resolved && /arduino/i.test(port.manufacturer)) {
           resolved = true;
-          return resolve(port.comName);
+          return resolve(port.path);
         }
       });
       if (!resolved) {

--- a/packages/serialport/test/integration.js
+++ b/packages/serialport/test/integration.js
@@ -56,7 +56,7 @@ function integrationTest(platform, testPort, Binding) {
             assert.isNull(err)
             let foundPort = false
             ports.forEach(port => {
-              if (normalizePath(port.comName) === normalizePath(testPort)) {
+              if (normalizePath(port.path) === normalizePath(testPort)) {
                 foundPort = true
               }
             })

--- a/packages/stream/stream.js
+++ b/packages/stream/stream.js
@@ -595,7 +595,7 @@ SerialPort.prototype.drain = function(callback) {
  */
 
 /**
- * Retrieves a list of available serial ports with metadata. Only the `comName` is guaranteed. If unavailable the other fields will be undefined. The `comName` is either the path or an identifier (eg `COM1`) used to open the SerialPort.
+ * Retrieves a list of available serial ports with metadata. Only the `path` is guaranteed. If unavailable the other fields will be undefined. The `path` is either the path or an identifier (eg `COM1`) used to open the SerialPort.
  *
  * We make an effort to identify the hardware attached and have consistent results between systems. Linux and OS X are mostly consistent. Windows relies on 3rd party device drivers for the information and is unable to guarantee the information. On windows If you have a USB connected device can we provide a serial number otherwise it will be `undefined`. The `pnpId` and `locationId` are not the same or present on all systems. The examples below were run with the same Arduino Uno.
  * @type {function}
@@ -605,7 +605,7 @@ SerialPort.prototype.drain = function(callback) {
 ```js
 // OSX example port
 {
-  comName: '/dev/tty.usbmodem1421',
+  path: '/dev/tty.usbmodem1421',
   manufacturer: 'Arduino (www.arduino.cc)',
   serialNumber: '752303138333518011C1',
   pnpId: undefined,
@@ -616,7 +616,7 @@ SerialPort.prototype.drain = function(callback) {
 
 // Linux example port
 {
-  comName: '/dev/ttyACM0',
+  path: '/dev/ttyACM0',
   manufacturer: 'Arduino (www.arduino.cc)',
   serialNumber: '752303138333518011C1',
   pnpId: 'usb-Arduino__www.arduino.cc__0043_752303138333518011C1-if00',
@@ -627,7 +627,7 @@ SerialPort.prototype.drain = function(callback) {
 
 // Windows example port
 {
-  comName: 'COM3',
+  path: 'COM3',
   manufacturer: 'Arduino LLC (www.arduino.cc)',
   serialNumber: '752303138333518011C1',
   pnpId: 'USB\\VID_2341&PID_0043\\752303138333518011C1',
@@ -642,7 +642,7 @@ var SerialPort = require('serialport');
 // callback approach
 SerialPort.list(function (err, ports) {
   ports.forEach(function(port) {
-    console.log(port.comName);
+    console.log(port.path);
     console.log(port.pnpId);
     console.log(port.manufacturer);
   });

--- a/packages/terminal/lib/terminal.js
+++ b/packages/terminal/lib/terminal.js
@@ -32,7 +32,7 @@ function listPorts() {
   SerialPort.list().then(
     ports => {
       ports.forEach(port => {
-        console.log(`${port.comName}\t${port.pnpId || ''}\t${port.manufacturer || ''}`)
+        console.log(`${port.path}\t${port.pnpId || ''}\t${port.manufacturer || ''}`)
       })
     },
     err => {
@@ -52,8 +52,8 @@ function askForPort() {
       name: 'serial-port-selection',
       message: 'Select a serial port to open',
       choices: ports.map((port, i) => ({
-        value: `[${i + 1}]\t${port.comName}\t${port.pnpId || ''}\t${port.manufacturer || ''}`,
-        name: port.comName,
+        value: `[${i + 1}]\t${port.path}\t${port.pnpId || ''}\t${port.manufacturer || ''}`,
+        name: port.path,
       })),
       validate: Boolean, // ensure we picked something
     })


### PR DESCRIPTION
We refer to the data as path everywhere but the port info object. This unifies them.

Accessing `comName` will log a warning for one major release and go away afterwards.